### PR TITLE
refactor(events): align LogRegistered with first three fields of CheckpointPublished

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,55 @@ transparency logs.
 ## Overview
 
 univocity provides Solidity contracts that verify transparency log checkpoints
-can only be published on-chain if they are consistent with previously published
-checkpoints. This prevents log operators from presenting different views of the
-log to different parties.
+can only be published on-chain if they are consistent with previously
+published checkpoints. This prevents log operators from presenting different
+views of the log to different parties.
 
 The verification logic implements the consistency proof format described in
 [draft-bryce-cose-receipts-mmr-profile](https://robinbryce.github.io/draft-bryce-cose-receipts-mmr-profile/draft-bryce-cose-receipts-mmr-profile.html).
 
-## Authorization Model (R5 / SCITT pattern)
+## Authorization model
 
-- **Signing authority**: Checkpoint content is authorized by a signature that chains from the previous checkpoint (SCITT issuer model).
-- **Publishing authority**: R5 payment receipts (SCITT COSE_Sign1 format) authorize the economic cost of publishing; the contract verifies receipt signature and bounds (checkpoint count, max height).
-- **Permissionless submission**: Given a validly signed checkpoint and valid payment receipt, any party may submit. The contract does not restrict `msg.sender` to the payer or signer.
-- **No on-chain ownership**: The checkpoint signing key is the effective “owner” of the log; there is no separate ownership state or bootstrap re-initialization.
+Every checkpoint is authorized by two checks; caller identity is not part of
+the model. See [ARC-0017 auth overview](docs/arc/arc-0017-auth-overview.md) for
+the full description and diagrams.
 
-## Contract Architecture
+1. **Grant (inclusion proof)**  
+   The publish supplies a **grant**: an inclusion proof in the target log’s
+   **owner** (the log against which the grant is verified). For the root’s
+   first checkpoint there is no prior owner, so the grant is self-inclusion
+   (index 0). For any other log, the owner is that log’s `authLogId` (root →
+   self; child authority → parent; data log → owning authority). The grant
+   leaf encodes bounds (minGrowth, maxHeight) and flags (e.g. GF_CREATE,
+   GF_EXTEND). First checkpoint to a new log requires `ownerLogId` in the
+   grant and inclusion verified against that owner.
 
-- **Univocity.sol**: Main contract; multi-log checkpoint state, bootstrap access control, R5 receipt verification, consistency proof verification.
-- **LibAuthorityVerifier**: Verifies SCITT-format payment receipts (COSE_Sign1 + CBOR claims) and inclusion in the authority log.
-- **consistencyReceipt**: Verifies MMR consistency receipt chain (decode CBOR proofs,
-  run `consistentRoots`/`consistentRootsMemory`, build detached payload commitment).
-- **cosecbor**: COSE_Sign1 Sig_structure and verify (ES256, KS256); CBOR
+2. **Consistency receipt (signed)**  
+   The consistency receipt is signed by the target log’s **signer**. For the
+   root’s first checkpoint the signer must be the **bootstrap key** (set at
+   deployment). For any other first checkpoint the signer is supplied in
+   **grantData** and stored as that log’s root key. For later checkpoints the
+   receipt must verify against the log’s stored root key (or a valid
+   delegation). The contract does not recover keys on-chain (verify-only).
+
+**Permissionless submission.** Any address may call `publishCheckpoint` with a
+valid grant and validly signed consistency receipt. The contract never checks
+`msg.sender` for authorization. The submitter is recorded in
+`CheckpointPublished` for attribution only.
+
+**No on-chain ownership.** The checkpoint signing key is the effective owner
+of the log; there is no separate ownership state or bootstrap
+re-initialization.
+
+## Contract architecture
+
+- **Univocity.sol** — Main contract: multi-log checkpoint state, bootstrap
+  access control, grant verification (inclusion in owner + bounds), and
+  consistency receipt verification (signature and proof chain).
+- **consistencyReceipt** — Verifies the MMR consistency receipt chain (decode
+  CBOR proofs, run `consistentRoots` / `consistentRootsMemory`, build
+  detached payload commitment). Used by Univocity; no storage references.
+- **cosecbor** — COSE_Sign1 Sig_structure and verify (ES256, KS256); CBOR
   extractAlgorithm from protected header (constants and free functions).
 
 ## Deployment
@@ -50,13 +78,17 @@ forge test --match-contract UnivocityInvariantTest   # invariant tests
 forge fmt     # format
 ```
 
-## Security Model
+## Security model
 
-- **Signing key = ownership**: Only the holder of the checkpoint signing key can produce valid checkpoints; there is no on-chain ownership to override this.
-- **Bootstrap immutable**: The bootstrap authority and signing keys are set at deployment and cannot be changed.
-- **Event sourcing**: All state-changing operations that affect transparency and verifiability emit events.
+- **Signing key = ownership** — Only the holder of the checkpoint signing
+  key can produce valid checkpoints; there is no on-chain ownership to
+  override this.
+- **Bootstrap immutable** — The bootstrap authority and signing keys are set
+  at deployment and cannot be changed.
+- **Event sourcing** — All state-changing operations that affect
+  transparency and verifiability emit events.
 
-## Reference Implementation
+## Reference implementation
 
 The MMR algorithms are ported from the reference Python implementation:
 [merkle-mountain-range-proofs](https://github.com/robinbryce/merkle-mountain-range-proofs)

--- a/src/contracts/Univocity.sol
+++ b/src/contracts/Univocity.sol
@@ -869,7 +869,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
                 : IUnivocity.LogKind.Data;
             config.authLogId = grantLogId;
 
-            emit LogRegistered(logId, _msgSender(), size);
+            emit LogRegistered(logId, grantLogId, config.rootKey);
         }
 
         delete log.accumulator;

--- a/src/interfaces/IUnivocityEvents.sol
+++ b/src/interfaces/IUnivocityEvents.sol
@@ -10,9 +10,12 @@ interface IUnivocityEvents {
         address indexed bootstrapAuthority, bytes32 indexed rootLogId
     );
 
-    /// @notice New log registered (first checkpoint)
+    /// @notice New log registered (first checkpoint). Same indexed fields as
+    ///    first three of CheckpointPublished (rootKey as keccak256(rootKey)).
     event LogRegistered(
-        bytes32 indexed logId, address indexed registeredBy, uint64 initialSize
+        bytes32 indexed logId,
+        bytes32 indexed grantLogId,
+        bytes indexed rootKey
     );
 
     /// @notice Checkpoint published (all logs including root/auth logs).

--- a/test/checkpoints/UnivocityStateAndEvents.t.sol
+++ b/test/checkpoints/UnivocityStateAndEvents.t.sol
@@ -37,6 +37,10 @@ contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
     }
 
     function test_publishCheckpoint_emitsLogRegistered() public {
+        vm.expectEmit(true, true, true, false);
+        emit LogRegistered(
+            TEST_LOG_ID, AUTHORITY_LOG_ID, abi.encodePacked(KS256_SIGNER)
+        );
         _publishFirstToTestLog(
             univocity, keccak256("peak1"), authorityLeaf0, grantTestLog
         );


### PR DESCRIPTION
## Summary

- LogRegistered now has logId, grantLogId, rootKey (all indexed); remove
  registeredBy and initialSize.
- Emit grantLogId and config.rootKey from _updateLogState on first
  checkpoint.
- Test expects LogRegistered(TEST_LOG_ID, AUTHORITY_LOG_ID, rootKey bytes).

Made with [Cursor](https://cursor.com)