### PR TITLE
feat(univocity): rename to grantIDTimestampBe and emit in CheckpointPublished

### DIFF
--- a/src/contracts/Univocity.sol
+++ b/src/contracts/Univocity.sol
@@ -245,7 +245,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function publishCheckpoint(
         IUnivocity.ConsistencyReceipt calldata consistencyParts,
         IUnivocity.InclusionProof calldata paymentInclusionProof,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant calldata publishGrant
     ) external {
         bytes32 logId = publishGrant.logId;
@@ -303,7 +303,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
             logId,
             claimedSize,
             paymentInclusionProof,
-            paymentIDTimestampBe,
+            grantIDTimestampBe,
             publishGrant,
             accMem
         );
@@ -316,7 +316,8 @@ contract Univocity is IUnivocity, IUnivocityErrors {
             paymentInclusionProof.path,
             authForInclusion,
             publishGrant.request,
-            rootKeyToSet
+            rootKeyToSet,
+            grantIDTimestampBe
         );
     }
 
@@ -327,13 +328,13 @@ contract Univocity is IUnivocity, IUnivocityErrors {
         bytes32 logId,
         uint64 claimedSize,
         IUnivocity.InclusionProof calldata paymentInclusionProof,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant calldata publishGrant,
         bytes32[] memory accMem
     ) internal returns (bytes32 authLogId) {
         IUnivocity.LogConfig storage config = _logConfigs[logId];
         bytes32 leafCommitment =
-            _leafCommitment(paymentIDTimestampBe, publishGrant);
+            _leafCommitment(grantIDTimestampBe, publishGrant);
 
         if (rootLogId == bytes32(0)) {
             // Rule 1: First checkpoint ever = root authority log. Grant must
@@ -769,7 +770,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     }
 
     function _leafCommitment(
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant calldata g
     ) private pure returns (bytes32) {
         bytes32 inner = sha256(
@@ -782,7 +783,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
                 g.grantData
             )
         );
-        return sha256(abi.encodePacked(paymentIDTimestampBe, inner));
+        return sha256(abi.encodePacked(grantIDTimestampBe, inner));
     }
 
     /// @notice Max height bound only; requires derived size (call after proof
@@ -844,7 +845,8 @@ contract Univocity is IUnivocity, IUnivocityErrors {
         bytes32[] calldata grantPath,
         bytes32 grantLogId,
         uint256 request,
-        bytes memory rootKeyToSet
+        bytes memory rootKeyToSet,
+        bytes8 grantIDTimestampBe
     ) private {
         LogState storage log = _logs[logId];
         IUnivocity.LogConfig storage config = _logConfigs[logId];
@@ -884,6 +886,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
             grantLogId,
             config.rootKey,
             _msgSender(),
+            grantIDTimestampBe,
             uint8(config.kind),
             size,
             accumulator,

--- a/src/interfaces/IUnivocity.sol
+++ b/src/interfaces/IUnivocity.sol
@@ -114,13 +114,14 @@ interface IUnivocity is IUnivocityEvents {
     /// @param paymentInclusionProof Pre-decoded (index, path). Root's first
     ///    checkpoint: index 0, path length up to MAX_HEIGHT. Other checkpoints:
     ///    inclusion in grant's owner (path length up to MAX_HEIGHT).
-    /// @param paymentIDTimestampBe Big-endian idtimestamp of included content.
+    /// @param grantIDTimestampBe Big-endian idtimestamp of included grant
+    ///    content (for leaf commitment).
     /// @param publishGrant LogId, grant flags, max_height, min_growth for leaf
     ///    commitment and bounds; any sender may submit.
     function publishCheckpoint(
         ConsistencyReceipt calldata consistencyParts,
         InclusionProof calldata paymentInclusionProof,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         PublishGrant calldata publishGrant
     ) external;
 }

--- a/src/interfaces/IUnivocityEvents.sol
+++ b/src/interfaces/IUnivocityEvents.sol
@@ -21,11 +21,13 @@ interface IUnivocityEvents {
     ///    grantLogId and rootKey are indexed (rootKey as keccak256(rootKey)).
     ///    grantLogId is the log in which the grant was verified. grantIndex
     ///    and grantPath are the inclusion proof payload (empty when no proof).
+    ///    grantIDTimestampBe is the big-endian idtimestamp used for the leaf.
     event CheckpointPublished(
         bytes32 indexed logId,
         bytes32 indexed grantLogId,
         bytes indexed rootKey,
         address sender,
+        bytes8 grantIDTimestampBe,
         uint8 logKind,
         uint64 size,
         bytes32[] accumulator,

--- a/test/checkpoints/Univocity.t.sol
+++ b/test/checkpoints/Univocity.t.sol
@@ -107,6 +107,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             AUTHORITY_LOG_ID,
             abi.encodePacked(KS256_SIGNER),
             address(this),
+            IDTIMESTAMP_AUTH,
             uint8(IUnivocity.LogKind.Authority),
             1,
             _toAcc(leaf0),

--- a/test/checkpoints/UnivocityStateAndEvents.t.sol
+++ b/test/checkpoints/UnivocityStateAndEvents.t.sol
@@ -53,6 +53,7 @@ contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
             AUTHORITY_LOG_ID,
             abi.encodePacked(KS256_SIGNER),
             address(this),
+            IDTIMESTAMP_TEST,
             uint8(IUnivocity.LogKind.Data),
             1,
             acc,

--- a/test/checkpoints/UnivocityTestHelper.sol
+++ b/test/checkpoints/UnivocityTestHelper.sol
@@ -127,7 +127,7 @@ contract ES256ReceiptDecodeVerifier {
     function getLeafCommitment(
         IUnivocity.ConsistencyReceipt calldata,
         IUnivocity.InclusionProof calldata,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant calldata g
     ) external pure returns (bytes32) {
         bytes32 inner = sha256(
@@ -140,7 +140,7 @@ contract ES256ReceiptDecodeVerifier {
                 g.grantData
             )
         );
-        return sha256(abi.encodePacked(paymentIDTimestampBe, inner));
+        return sha256(abi.encodePacked(grantIDTimestampBe, inner));
     }
 }
 
@@ -162,7 +162,7 @@ contract GrantDecodeHarness {
     function decodeGrantFourArgs(
         IUnivocity.ConsistencyReceipt calldata,
         IUnivocity.InclusionProof calldata,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant calldata g
     ) external pure returns (DecodedGrant memory out) {
         out.logId = g.logId;
@@ -182,7 +182,7 @@ contract GrantDecodeHarness {
                 g.grantData
             )
         );
-        out.leaf = sha256(abi.encodePacked(paymentIDTimestampBe, inner));
+        out.leaf = sha256(abi.encodePacked(grantIDTimestampBe, inner));
     }
 }
 
@@ -193,7 +193,7 @@ contract GrantDecodeHarnessEncoded {
     function decodeGrantEncoded(
         IUnivocity.ConsistencyReceipt calldata,
         IUnivocity.InclusionProof calldata,
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         bytes calldata encodedGrant
     ) external pure returns (bytes32 leaf) {
         IUnivocity.PublishGrant memory g = abi.decode(
@@ -209,7 +209,7 @@ contract GrantDecodeHarnessEncoded {
                 g.grantData
             )
         );
-        return sha256(abi.encodePacked(paymentIDTimestampBe, inner));
+        return sha256(abi.encodePacked(grantIDTimestampBe, inner));
     }
 }
 
@@ -338,7 +338,7 @@ abstract contract UnivocityTestHelper is Test {
     }
 
     function _leafCommitment(
-        bytes8 paymentIDTimestampBe,
+        bytes8 grantIDTimestampBe,
         IUnivocity.PublishGrant memory g
     ) internal pure returns (bytes32) {
         bytes32 inner = sha256(
@@ -351,7 +351,7 @@ abstract contract UnivocityTestHelper is Test {
                 g.grantData
             )
         );
-        return sha256(abi.encodePacked(paymentIDTimestampBe, inner));
+        return sha256(abi.encodePacked(grantIDTimestampBe, inner));
     }
 
     function _publishGrant(


### PR DESCRIPTION
## Summary

- Rename publishCheckpoint parameter paymentIDTimestampBe to
  grantIDTimestampBe in IUnivocity and Univocity.
- Thread grantIDTimestampBe into _updateLogState and emit it in
  CheckpointPublished as a new non-indexed field.
- Extend IUnivocityEvents.CheckpointPublished with bytes8 grantIDTimestampBe.
- Update test helpers and expectEmit tests for the new event and param name.

Made with [Cursor](https://cursor.com)