### PR TITLE
refactor(types): move shared types to interfaces/Types.sol

### DIFF
--- a/src/checkpoints/lib/consistencyReceipt.sol
+++ b/src/checkpoints/lib/consistencyReceipt.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.24;
 
-import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {ConsistencyProof} from "@univocity/interfaces/Types.sol";
 import {
     consistentRootsMemory
 } from "@univocity/algorithms/consistentRoots.sol";
@@ -18,7 +18,7 @@ import {
 ///    for grant bounds and state update.
 function verifyConsistencyProofChain(
     bytes32[] memory initialAccumulator,
-    IUnivocity.ConsistencyProof[] calldata decodedProofs
+    ConsistencyProof[] calldata decodedProofs
 ) pure returns (bytes32[] memory finalAccumulator) {
     uint256 n = decodedProofs.length;
     if (n == 0) {
@@ -29,7 +29,7 @@ function verifyConsistencyProofChain(
     bytes32[] memory accumulatorFrom;
 
     for (uint256 idx = 0; idx < n; idx++) {
-        IUnivocity.ConsistencyProof calldata p = decodedProofs[idx];
+        ConsistencyProof calldata p = decodedProofs[idx];
 
         if (idx == 0) {
             accumulatorFrom = initialAccumulator;

--- a/src/contracts/Univocity.sol
+++ b/src/contracts/Univocity.sol
@@ -2,6 +2,16 @@
 pragma solidity ^0.8.24;
 
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    LogKind,
+    LogConfig,
+    LogState,
+    ConsistencyProof,
+    ConsistencyReceipt,
+    InclusionProof,
+    DelegationProof,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 import {ALG_ES256, ALG_KS256} from "@univocity/cosecbor/constants.sol";
 import {
@@ -69,7 +79,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     bytes32 public rootLogId;
 
     mapping(bytes32 => LogState) private _logs;
-    mapping(bytes32 => IUnivocity.LogConfig) private _logConfigs;
+    mapping(bytes32 => LogConfig) private _logConfigs;
 
     /// @notice Grant flag: create a new log (first checkpoint to that logId).
     uint256 public constant GF_CREATE = uint256(1) << 32;
@@ -172,7 +182,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function logConfig(bytes32 logId)
         external
         view
-        returns (IUnivocity.LogConfig memory)
+        returns (LogConfig memory)
     {
         return _logConfigs[logId];
     }
@@ -208,14 +218,14 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     ///   Extend existing log: inclusion verified against config.authLogId
     ///   (rule 2). Grant bounds minGrowth, maxHeight checked (rule 4).
     function publishCheckpoint(
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
-        IUnivocity.InclusionProof calldata grantInclusionProof,
+        ConsistencyReceipt calldata consistencyParts,
+        InclusionProof calldata grantInclusionProof,
         bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant calldata publishGrant
+        PublishGrant calldata publishGrant
     ) external {
         bytes32 logId = publishGrant.logId;
         LogState storage log = _logs[logId];
-        IUnivocity.LogConfig storage config = _logConfigs[logId];
+        LogConfig storage config = _logConfigs[logId];
 
         if (consistencyParts.consistencyProofs.length == 0) {
             revert InvalidConsistencyProof();
@@ -292,13 +302,13 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function _applyInclusionGrant(
         bytes32 logId,
         uint64 claimedSize,
-        IUnivocity.InclusionProof calldata grantInclusionProof,
+        InclusionProof calldata grantInclusionProof,
         bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant calldata publishGrant,
+        PublishGrant calldata publishGrant,
         bytes32[] memory accMem,
         bytes memory rootKeyToSet
     ) internal returns (bytes32 authLogId) {
-        IUnivocity.LogConfig storage config = _logConfigs[logId];
+        LogConfig storage config = _logConfigs[logId];
         bytes32 leafCommitment =
             _leafCommitment(grantIDTimestampBe, publishGrant);
 
@@ -337,7 +347,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
             }
 
             config.initializedAt = block.number;
-            config.kind = IUnivocity.LogKind.Authority;
+            config.kind = LogKind.Authority;
             config.authLogId = logId;
             if (rootKeyToSet.length == 64 || rootKeyToSet.length == 20) {
                 config.rootKey = rootKeyToSet;
@@ -377,7 +387,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
                     );
                 }
 
-                config.kind = IUnivocity.LogKind.Authority;
+                config.kind = LogKind.Authority;
             } else if (req == GC_DATA_LOG) {
                 if ((g & GF_DATA_LOG) == 0) {
                     revert GrantRequirement(
@@ -385,7 +395,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
                     );
                 }
 
-                config.kind = IUnivocity.LogKind.Data;
+                config.kind = LogKind.Data;
             } else {
                 revert GrantRequirement(
                     GF_CREATE | GF_AUTH_LOG | GF_DATA_LOG, 0
@@ -438,10 +448,10 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function _verifyCheckpointSignature(
         bytes32 logId,
         uint64 claimedSize,
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
+        ConsistencyReceipt calldata consistencyParts,
         bytes memory detachedPayload,
-        IUnivocity.LogConfig storage config,
-        IUnivocity.DelegationProof calldata delegationProof,
+        LogConfig storage config,
+        DelegationProof calldata delegationProof,
         uint256 grant,
         bytes calldata grantData
     ) internal view returns (bytes memory initialRoot) {
@@ -485,10 +495,10 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function _verifyCheckpointSignatureES256(
         bytes32 logId,
         uint64 claimedSize,
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
+        ConsistencyReceipt calldata consistencyParts,
         bytes memory detachedPayload,
-        IUnivocity.LogConfig storage config,
-        IUnivocity.DelegationProof calldata delegationProof,
+        LogConfig storage config,
+        DelegationProof calldata delegationProof,
         uint256,
         /* grant */
         bytes calldata grantData
@@ -543,10 +553,10 @@ contract Univocity is IUnivocity, IUnivocityErrors {
         bytes32 logId,
         uint64,
         /* claimedSize */
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
+        ConsistencyReceipt calldata consistencyParts,
         bytes memory detachedPayload,
-        IUnivocity.LogConfig storage config,
-        IUnivocity.DelegationProof calldata delegationProof,
+        LogConfig storage config,
+        DelegationProof calldata delegationProof,
         uint256,
         /* grant */
         bytes calldata grantData
@@ -605,10 +615,10 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     function _checkpointSignersES256(
         bytes32 logId,
         uint64 claimedSize,
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
+        ConsistencyReceipt calldata consistencyParts,
         bytes memory detachedPayload,
-        IUnivocity.LogConfig storage config,
-        IUnivocity.DelegationProof calldata delegationProof,
+        LogConfig storage config,
+        DelegationProof calldata delegationProof,
         bytes calldata grantData
     )
         internal
@@ -700,10 +710,12 @@ contract Univocity is IUnivocity, IUnivocityErrors {
 
     /// @notice Revert if any consistency proof payload array length exceeds
     ///    MAX_HEIGHT (read from calldata; no copy).
-    function _validateConsistencyProofBounds(IUnivocity
-                .ConsistencyProof[] calldata decodedProofs) private pure {
+    function _validateConsistencyProofBounds(ConsistencyProof[] calldata decodedProofs)
+        private
+        pure
+    {
         for (uint256 i = 0; i < decodedProofs.length; i++) {
-            IUnivocity.ConsistencyProof calldata p = decodedProofs[i];
+            ConsistencyProof calldata p = decodedProofs[i];
             if (p.paths.length > MAX_HEIGHT) {
                 revert ProofPayloadExceedsMaxHeight();
             }
@@ -760,7 +772,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
 
     function _leafCommitment(
         bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant calldata g
+        PublishGrant calldata g
     ) private pure returns (bytes32) {
         bytes32 inner = sha256(
             abi.encodePacked(
@@ -779,7 +791,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
     ///    chain).
     function _checkPublishGrantBoundsMaxHeight(
         uint64 size,
-        IUnivocity.PublishGrant calldata g
+        PublishGrant calldata g
     ) private pure {
         if (g.maxHeight != 0 && size > g.maxHeight) {
             revert MaxHeightExceeded(size, g.maxHeight);
@@ -834,7 +846,7 @@ contract Univocity is IUnivocity, IUnivocityErrors {
         bytes32[] calldata grantPath
     ) private {
         LogState storage log = _logs[logId];
-        IUnivocity.LogConfig storage config = _logConfigs[logId];
+        LogConfig storage config = _logConfigs[logId];
 
         delete log.accumulator;
         for (uint256 i = 0; i < accumulator.length; i++) {

--- a/src/interfaces/IUnivocal.sol
+++ b/src/interfaces/IUnivocal.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import {LogState} from "@univocity/interfaces/Types.sol";
+
+/// @title IUnivocal
+/// @notice Interface to a split view protected "univocal" log state.
+interface IUnivocal {
+    function logState(bytes32 logId) external view returns (LogState memory);
+}
+

--- a/src/interfaces/IUnivocity.sol
+++ b/src/interfaces/IUnivocity.sol
@@ -2,87 +2,18 @@
 pragma solidity ^0.8.24;
 
 import {IUnivocityEvents} from "./IUnivocityEvents.sol";
+import {
+    LogConfig,
+    LogState,
+    ConsistencyReceipt,
+    InclusionProof,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 
 /// @title IUnivocity
 /// @notice Interface for univocity transparency log contract (payment-bounded
 ///    checkpoint authorization via grant inclusion proof and bounds).
 interface IUnivocity is IUnivocityEvents {
-    /// @notice Log role in the hierarchy (ARC-0017). 0 = not set (uninitialized).
-    enum LogKind {
-        Undefined,
-        Authority,
-        Data
-    }
-
-    /// @notice Immutable per-log config (set at first checkpoint).
-    struct LogConfig {
-        LogKind kind;
-        bytes32 authLogId;
-        bytes rootKey;
-        uint256 initializedAt;
-    }
-
-    /// @notice Mutable log state only (config in separate mapping).
-    struct LogState {
-        bytes32[] accumulator;
-        uint64 size;
-    }
-
-    /// @notice Pre-decoded consistency proof payload (MMR profile). One
-    ///    element per consistency proof; no CBOR decode on-chain.
-    struct ConsistencyProof {
-        uint64 treeSize1;
-        uint64 treeSize2;
-        bytes32[][] paths;
-        bytes32[] rightPeaks;
-    }
-
-    /// @notice Pre-decoded inclusion proof (index + path). Empty path means
-    ///    no payment proof.
-    struct InclusionProof {
-        uint64 index;
-        bytes32[] path;
-    }
-
-    /// @notice Pre-decoded consistency receipt (plan 0016). No COSE envelope
-    ///    parse on-chain. Consistency proofs are pre-decoded (no CBOR).
-    struct ConsistencyReceipt {
-        bytes protectedHeader;
-        bytes signature;
-        ConsistencyProof[] consistencyProofs;
-        DelegationProof delegationProof;
-    }
-
-    /// @notice Minimal delegation proof (plan 0016). No cert decode.
-    ///    delegationKey is alg-specific opaque bytes; for P-256/ES256 it is
-    ///    64 bytes (x || y). Decoding requires alg == P-256/ES256.
-    struct DelegationProof {
-        bytes delegationKey;
-        uint64 mmrStart;
-        uint64 mmrEnd;
-        uint64 alg;
-        bytes signature;
-    }
-
-    /// @notice Caller-supplied publish grant for leaf commitment and bounds.
-    ///    grant (in commitment): GF_CREATE (1<<32), GF_EXTEND (1<<33),
-    ///    GF_AUTH_LOG (1), GF_DATA_LOG (2). request is NOT in the commitment;
-    ///    high 32 bits = GC_AUTH_LOG or GC_DATA_LOG (mutually exclusive), must
-    ///    be allowed by grant. Log kind for new logs is set from request.
-    ///    Leaf inner hash: logId, grant, maxHeight, minGrowth, ownerLogId,
-    ///    grantData (no request). First checkpoint: grantData supplies the
-    ///    signer (root) key; receipt verified against it (verify-only; no
-    ///    on-chain recovery).
-    struct PublishGrant {
-        bytes32 logId;
-        uint256 grant;
-        uint256 request;
-        uint64 maxHeight;
-        uint64 minGrowth;
-        bytes32 ownerLogId;
-        bytes grantData;
-    }
-
     // === View Functions ===
 
     /// @notice Bootstrap key in opaque form (same as constructor). Plan 0018.

--- a/src/interfaces/Types.sol
+++ b/src/interfaces/Types.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+/// @notice Log role in the hierarchy (ARC-0017). 0 = not set (uninitialized).
+enum LogKind {
+    Undefined,
+    Authority,
+    Data
+}
+
+/// @notice Immutable per-log config (set at first checkpoint).
+struct LogConfig {
+    LogKind kind;
+    bytes32 authLogId;
+    bytes rootKey;
+    uint256 initializedAt;
+}
+
+/// @notice Mutable log state only (config in separate mapping).
+struct LogState {
+    bytes32[] accumulator;
+    uint64 size;
+}
+
+/// @notice Pre-decoded consistency proof payload (MMR profile). One
+///    element per consistency proof; no CBOR decode on-chain.
+struct ConsistencyProof {
+    uint64 treeSize1;
+    uint64 treeSize2;
+    bytes32[][] paths;
+    bytes32[] rightPeaks;
+}
+
+/// @notice Pre-decoded inclusion proof (index + path). Empty path means
+///    no payment proof.
+struct InclusionProof {
+    uint64 index;
+    bytes32[] path;
+}
+
+/// @notice Minimal delegation proof (plan 0016). No cert decode.
+///    delegationKey is alg-specific opaque bytes; for P-256/ES256 it is
+///    64 bytes (x || y). Decoding requires alg == P-256/ES256.
+struct DelegationProof {
+    bytes delegationKey;
+    uint64 mmrStart;
+    uint64 mmrEnd;
+    uint64 alg;
+    bytes signature;
+}
+
+/// @notice Pre-decoded consistency receipt (plan 0016). No COSE envelope
+///    parse on-chain. Consistency proofs are pre-decoded (no CBOR).
+struct ConsistencyReceipt {
+    bytes protectedHeader;
+    bytes signature;
+    ConsistencyProof[] consistencyProofs;
+    DelegationProof delegationProof;
+}
+
+/// @notice Caller-supplied publish grant for leaf commitment and bounds.
+///    grant (in commitment): GF_CREATE (1<<32), GF_EXTEND (1<<33),
+///    GF_AUTH_LOG (1), GF_DATA_LOG (2). request is NOT in the commitment;
+///    high 32 bits = GC_AUTH_LOG or GC_DATA_LOG (mutually exclusive), must
+///    be allowed by grant. Log kind for new logs is set from request.
+///    Leaf inner hash: logId, grant, maxHeight, minGrowth, ownerLogId,
+///    grantData (no request). First checkpoint: grantData supplies the
+///    signer (root) key; receipt verified against it (verify-only; no
+///    on-chain recovery).
+struct PublishGrant {
+    bytes32 logId;
+    uint256 grant;
+    uint256 request;
+    uint64 maxHeight;
+    uint64 minGrowth;
+    bytes32 ownerLogId;
+    bytes grantData;
+}

--- a/test/checkpoints/Univocity.t.sol
+++ b/test/checkpoints/Univocity.t.sol
@@ -6,6 +6,15 @@ import {console} from "forge-std/console.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
 import {IUnivocityEvents} from "@univocity/interfaces/IUnivocityEvents.sol";
+import {
+    ConsistencyProof,
+    ConsistencyReceipt,
+    DelegationProof,
+    InclusionProof,
+    LogConfig,
+    LogKind,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 import {
     buildDetachedPayloadCommitment
@@ -36,7 +45,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         // So we use wrong leaf in accumulator => InvalidReceiptInclusionProof.
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -46,7 +55,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 wrongLeaf = keccak256("wrong");
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(wrongLeaf));
         vm.expectRevert(IUnivocityErrors.InvalidReceiptInclusionProof.selector);
         fresh.publishCheckpoint(
@@ -61,7 +70,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -71,10 +80,10 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
-        IUnivocity.InclusionProof memory proofWithNonZeroIndex =
-            IUnivocity.InclusionProof({index: 1, path: new bytes32[](0)});
+        InclusionProof memory proofWithNonZeroIndex =
+            InclusionProof({index: 1, path: new bytes32[](0)});
         vm.expectRevert(IUnivocityErrors.InvalidPaymentReceipt.selector);
         fresh.publishCheckpoint(
             consistency, proofWithNonZeroIndex, IDTIMESTAMP_AUTH, g
@@ -85,7 +94,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_firstCheckpoint_emitsPaymentIndexZeroWhenPathEmpty() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -95,7 +104,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         bytes32[] memory emptyPath;
         vm.expectEmit(true, true, true, false);
@@ -105,7 +114,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER),
             address(this),
             IDTIMESTAMP_AUTH,
-            uint8(IUnivocity.LogKind.Authority),
+            uint8(LogKind.Authority),
             1,
             _toAcc(leaf0),
             uint64(0),
@@ -122,9 +131,8 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
 
     /// @notice Phase D.1: First bootstrap sets kind=Authority, authLogId=self (ADR-0004).
     function test_logConfig_bootstrapSetsAuthorityKind() public view {
-        IUnivocity.LogConfig memory config =
-            univocity.logConfig(AUTHORITY_LOG_ID);
-        assertEq(uint8(config.kind), uint8(IUnivocity.LogKind.Authority));
+        LogConfig memory config = univocity.logConfig(AUTHORITY_LOG_ID);
+        assertEq(uint8(config.kind), uint8(LogKind.Authority));
         assertEq(config.authLogId, AUTHORITY_LOG_ID); // root's parent is self
         assertGt(config.initializedAt, 0);
     }
@@ -134,7 +142,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
         bytes32 childId = keccak256("child-authority");
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -144,12 +152,12 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
-        IUnivocity.PublishGrant memory gChild = _publishGrant(
+        PublishGrant memory gChild = _publishGrant(
             childId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -159,9 +167,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leafChild = _leafCommitment(IDTIMESTAMP_TEST, gChild);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(leaf0, leafChild);
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -185,8 +193,8 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             gChild
         );
 
-        IUnivocity.LogConfig memory config = fresh.logConfig(childId);
-        assertEq(uint8(config.kind), uint8(IUnivocity.LogKind.Authority));
+        LogConfig memory config = fresh.logConfig(childId);
+        assertEq(uint8(config.kind), uint8(LogKind.Authority));
         assertEq(config.authLogId, AUTHORITY_LOG_ID);
         assertEq(fresh.logState(childId).size, 1);
     }
@@ -194,7 +202,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_firstPublish_emitsInitialized() public {
         Univocity newUnivocity =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -204,7 +212,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
 
         vm.expectEmit(true, true, false, false);
@@ -222,9 +230,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_firstPublish_revertsIfReceiptEmpty() public {
         Univocity newUnivocity =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(keccak256("peak")));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -254,7 +262,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
         bytes32 otherLogId = keccak256("other-log");
-        IUnivocity.PublishGrant memory gAuthority = _publishGrant(
+        PublishGrant memory gAuthority = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -265,7 +273,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         // Grant passes first-root check (GF_CREATE, GC_AUTH_LOG) but logId differs
         // so leafCommitment(g) != leaf0 => inclusion fails.
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             otherLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -275,7 +283,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, gAuthority);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         vm.expectRevert(IUnivocityErrors.InvalidReceiptInclusionProof.selector);
         fresh.publishCheckpoint(
@@ -288,7 +296,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -297,7 +305,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             bytes32(0),
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(keccak256("wrong-peak")));
 
         vm.expectRevert(IUnivocityErrors.InvalidReceiptInclusionProof.selector);
@@ -309,7 +317,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_firstCheckpoint_succeedsFromNonBootstrapSender() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -319,7 +327,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
 
         vm.prank(address(0x999));
@@ -336,7 +344,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -346,7 +354,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 expectedLeaf = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(expectedLeaf));
         fresh.publishCheckpoint(
             consistency, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g
@@ -362,12 +370,11 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         _publishFirstToTestLog(
             univocity, keccak256("peak1"), authorityLeaf0, grantTestLog
         );
-        IUnivocity.ConsistencyReceipt memory consistency1to3 =
-            _buildConsistencyReceipt1To3(
-                keccak256("peak1"), authorityLeaf1, keccak256("leaf2")
-            );
+        ConsistencyReceipt memory consistency1to3 = _buildConsistencyReceipt1To3(
+            keccak256("peak1"), authorityLeaf1, keccak256("leaf2")
+        );
         bytes32[] memory pathDec = _path1(authorityLeaf0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -383,7 +390,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             g
         );
 
-        IUnivocity.ConsistencyReceipt memory consistency0to2 =
+        ConsistencyReceipt memory consistency0to2 =
             _buildConsistencyReceipt0To2(keccak256("p0"), keccak256("p1"));
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -404,12 +411,12 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         _publishFirstToTestLog(
             univocity, keccak256("peak1"), authorityLeaf0, grantTestLog
         );
-        IUnivocity.ConsistencyReceipt memory wrongConsistency =
+        ConsistencyReceipt memory wrongConsistency =
             _buildConsistencyReceipt1To3WrongPeakCount(
                 keccak256("peak1"), authorityLeaf1, keccak256("leaf2")
             );
         bytes32[] memory pathWrong = _path1(authorityLeaf0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID, GRANT_DATA, GC_DATA_LOG, 0, 0, AUTHORITY_LOG_ID, ""
         );
         vm.expectRevert(
@@ -430,18 +437,17 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_publishCheckpoint_ks256WithDelegation_revertsDelegationNotSupported()
         public
     {
-        IUnivocity.ConsistencyReceipt memory consistency =
-            _buildConsistencyReceipt2To3(
-                authorityLeaf0, authorityLeaf1, keccak256("third")
-            );
-        consistency.delegationProof = IUnivocity.DelegationProof({
+        ConsistencyReceipt memory consistency = _buildConsistencyReceipt2To3(
+            authorityLeaf0, authorityLeaf1, keccak256("third")
+        );
+        consistency.delegationProof = DelegationProof({
             delegationKey: new bytes(64),
             mmrStart: 0,
             mmrEnd: 1,
             alg: 0,
             signature: new bytes(64)
         });
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -468,14 +474,13 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
 
     /// @notice Empty consistency proof chain reverts InvalidConsistencyProof.
     function test_publishCheckpoint_revertsOnEmptyConsistencyProofs() public {
-        IUnivocity.ConsistencyReceipt memory emptyProofs =
-            IUnivocity.ConsistencyReceipt({
-                protectedHeader: hex"a1013a00010106",
-                signature: hex"",
-                consistencyProofs: new IUnivocity.ConsistencyProof[](0),
-                delegationProof: _emptyDelegationProof()
-            });
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        ConsistencyReceipt memory emptyProofs = ConsistencyReceipt({
+            protectedHeader: hex"a1013a00010106",
+            signature: hex"",
+            consistencyProofs: new ConsistencyProof[](0),
+            delegationProof: _emptyDelegationProof()
+        });
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -501,14 +506,14 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             grantTestLog
         );
 
-        IUnivocity.ConsistencyReceipt memory wrongConsistency =
+        ConsistencyReceipt memory wrongConsistency =
             _buildConsistencyReceipt1To3WrongProof(
                 0xaf5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc,
                 authorityLeaf1,
                 bytes32(0)
             );
         bytes32[] memory pathWrongProof;
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID, GRANT_DATA, GC_DATA_LOG, 0, 0, AUTHORITY_LOG_ID, ""
         );
         // Accumulator length is checked immediately after the consistency proof chain;
@@ -533,11 +538,10 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     /// @notice ADR-0004: non-bootstrap can extend root with valid grant
     ///    (permissionless submission; root extension requires grant in root).
     function test_publishCheckpoint_authorityLogOnlyBootstrap() public {
-        IUnivocity.ConsistencyReceipt memory consistency2 =
-            _buildConsistencyReceipt2To3(
-                authorityLeaf0, authorityLeaf1, keccak256("third")
-            );
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        ConsistencyReceipt memory consistency2 = _buildConsistencyReceipt2To3(
+            authorityLeaf0, authorityLeaf1, keccak256("third")
+        );
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -558,9 +562,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     }
 
     function test_publishCheckpoint_nonBootstrapNeedsReceipt() public {
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(keccak256("peak1")));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -582,7 +586,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         public
     {
         bytes32 otherLogId = keccak256("other-log");
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             otherLogId,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -591,7 +595,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             AUTHORITY_LOG_ID,
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(keccak256("peak1")));
         bytes32[] memory pathEmpty;
         vm.expectRevert(
@@ -627,7 +631,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         public
     {
         bytes32 newLogId = keccak256("new-data-log");
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             newLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -637,7 +641,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf = _leafCommitment(IDTIMESTAMP_TEST, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf));
         bytes32[] memory path = _path1(authorityLeaf0);
         vm.expectRevert(IUnivocityErrors.InvalidPaymentReceipt.selector);
@@ -658,7 +662,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -669,7 +673,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g);
         bytes32[] memory accMem = _toAcc(leaf0);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(accMem, es256Pk);
         ES256RecoveredKeyFromReceiptHelper oneArg =
             new ES256RecoveredKeyFromReceiptHelper();
@@ -691,7 +695,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -700,10 +704,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             bytes32(0),
             abi.encodePacked(pubX, pubY)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
-            _buildConsistencyReceiptES256(
-                _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
-            );
+        ConsistencyReceipt memory consistency = _buildConsistencyReceiptES256(
+            _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
+        );
         ES256RecoveredKeyFromReceiptHelper oneArg =
             new ES256RecoveredKeyFromReceiptHelper();
         (bytes32 peakHelper, bytes32 kxHelper, bytes32 kyHelper) =
@@ -727,7 +730,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -736,10 +739,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             bytes32(0),
             abi.encodePacked(pubX, pubY)
         );
-        IUnivocity.ConsistencyReceipt memory consistency0 =
-            _buildConsistencyReceiptES256(
-                _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
-            );
+        ConsistencyReceipt memory consistency0 = _buildConsistencyReceiptES256(
+            _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
+        );
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         (, bytes32 kx, bytes32 ky) = verifier.decodeAndRecover(
             consistency0, _emptyInclusionProof(), idtimestampBe, g
@@ -748,7 +750,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         bytes32 leafRebuild = verifier.getLeafCommitment(
             consistency0, _emptyInclusionProof(), idtimestampBe, g
         );
-        IUnivocity.ConsistencyReceipt memory consistencyRebuild =
+        ConsistencyReceipt memory consistencyRebuild =
             _buildConsistencyReceiptES256(_toAcc(leafRebuild), es256Pk);
         (bytes32 peakV, bytes32 kxV, bytes32 kyV) = verifier.decodeAndRecover(
             consistencyRebuild, _emptyInclusionProof(), idtimestampBe, g
@@ -764,7 +766,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -773,10 +775,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             bytes32(0),
             abi.encodePacked(pubX, pubY)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
-            _buildConsistencyReceiptES256(
-                _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
-            );
+        ConsistencyReceipt memory consistency = _buildConsistencyReceiptES256(
+            _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
+        );
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         (bytes32 peak4, bytes32 kx4, bytes32 ky4) = verifier.decodeAndRecover(
             consistency, _emptyInclusionProof(), idtimestampBe, g
@@ -804,13 +805,13 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
                 abi.encodePacked(bytes32(0), bytes32(0))
             )
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leaf0), es256Pk);
         ES256RecoveredKeyFromReceiptHelper oneArg =
             new ES256RecoveredKeyFromReceiptHelper();
         (bytes32 kx, bytes32 ky) = oneArg.getRecoveredKey(consistency);
         for (uint256 i = 0; i < 3; i++) {
-            IUnivocity.PublishGrant memory gi = _publishGrant(
+            PublishGrant memory gi = _publishGrant(
                 AUTHORITY_LOG_ID,
                 GRANT_ROOT,
                 GC_AUTH_LOG,
@@ -826,7 +827,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             if (kxNext == kx && kyNext == ky) break;
             (kx, ky) = (kxNext, kyNext);
         }
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -864,13 +865,13 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
                 abi.encodePacked(bytes32(0), bytes32(0))
             )
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leaf0), es256Pk);
         ES256RecoveredKeyFromReceiptHelper oneArg =
             new ES256RecoveredKeyFromReceiptHelper();
         (bytes32 kx, bytes32 ky) = oneArg.getRecoveredKey(consistency);
         for (uint256 i = 0; i < 3; i++) {
-            IUnivocity.PublishGrant memory gi = _publishGrant(
+            PublishGrant memory gi = _publishGrant(
                 AUTHORITY_LOG_ID,
                 GRANT_ROOT,
                 GC_AUTH_LOG,
@@ -896,7 +897,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         console.logBytes32(kx);
         console.logBytes32(ky);
 
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -924,7 +925,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -935,7 +936,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leafMemory = _leafCommitment(idtimestampBe, g);
         bytes32[] memory accMem = _toAcc(leafMemory);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(accMem, es256Pk);
         GrantDecodeHarness harness = new GrantDecodeHarness();
         GrantDecodeHarness.DecodedGrant memory decoded =
@@ -966,7 +967,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -976,7 +977,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(pubX, pubY)
         );
         bytes32[] memory accMem = _toAcc(_leafCommitment(idtimestampBe, g));
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(accMem, es256Pk);
         GrantDecodeHarness harness = new GrantDecodeHarness();
         GrantDecodeHarness.DecodedGrant memory d = harness.decodeGrantFourArgs(
@@ -1007,7 +1008,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1018,7 +1019,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g);
         bytes32[] memory accMem = _toAcc(leaf0);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(accMem, es256Pk);
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         (, bytes32 kx, bytes32 ky) = verifier.decodeAndRecover(
@@ -1052,7 +1053,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1061,10 +1062,9 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             bytes32(0),
             abi.encodePacked(pubX, pubY)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
-            _buildConsistencyReceiptES256(
-                _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
-            );
+        ConsistencyReceipt memory consistency = _buildConsistencyReceiptES256(
+            _toAcc(_leafCommitment(idtimestampBe, g)), es256Pk
+        );
         ES256RecoveredKeyFromReceiptHelper oneArg =
             new ES256RecoveredKeyFromReceiptHelper();
         (bytes32 kx, bytes32 ky) = oneArg.getRecoveredKey(consistency);
@@ -1092,7 +1092,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1102,10 +1102,10 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(pubX, pubY)
         );
         bytes32 leafA = _leafCommitment(idtimestampBe, g);
-        IUnivocity.ConsistencyReceipt memory consistencyA =
+        ConsistencyReceipt memory consistencyA =
             _buildConsistencyReceiptES256(_toAcc(leafA), es256Pk);
         bytes32 leafB = keccak256("different");
-        IUnivocity.ConsistencyReceipt memory consistencyB =
+        ConsistencyReceipt memory consistencyB =
             _buildConsistencyReceiptES256(_toAcc(leafB), es256Pk);
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         bytes32 leafHelperA = verifier.getLeafCommitment(
@@ -1128,7 +1128,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1138,7 +1138,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(pubX, pubY)
         );
         bytes32 leafTest = _leafCommitment(idtimestampBe, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leafTest), es256Pk);
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         bytes32 leafHelper = verifier.getLeafCommitment(
@@ -1164,7 +1164,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         bytes8 idtimestampBe = bytes8(0);
         ES256ReceiptDecodeVerifier verifier = new ES256ReceiptDecodeVerifier();
         GrantDecodeHarness harness = new GrantDecodeHarness();
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1174,7 +1174,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(pubX, pubY)
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leaf0), es256Pk);
         (, bytes32 kx, bytes32 ky) = verifier.decodeAndRecover(
             consistency, _emptyInclusionProof(), idtimestampBe, g
@@ -1209,7 +1209,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1220,7 +1220,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leafMemory = _leafCommitment(idtimestampBe, g);
         bytes32[] memory accMem = _toAcc(leafMemory);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(accMem, es256Pk);
         bytes memory encodedGrant = abi.encode(g);
         GrantDecodeHarnessEncoded harnessEnc = new GrantDecodeHarnessEncoded();
@@ -1241,7 +1241,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1251,7 +1251,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(pubX, pubY)
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leaf0), es256Pk);
         vm.prank(BOOTSTRAP);
         Univocity es256Univocity =
@@ -1276,7 +1276,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             new Univocity(ALG_ES256, abi.encodePacked(pubX, pubY));
 
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1287,7 +1287,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g);
         uint256 otherPk = 2;
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceiptES256(_toAcc(leaf0), otherPk);
 
         vm.expectRevert(
@@ -1305,7 +1305,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     {
         Univocity ks256Univocity =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1315,13 +1315,13 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         ks256Univocity.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
         uint256 es256Pk = 1;
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1331,7 +1331,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf1 = _leafCommitment(IDTIMESTAMP_AUTH, g1);
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2ES256(leaf0, leaf1, es256Pk);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1353,7 +1353,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         uint256 es256Pk = 1;
         (uint256 pubX, uint256 pubY) = vm.publicKeyP256(es256Pk);
         bytes8 idtimestampBe = bytes8(0);
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1364,7 +1364,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         bytes32 leaf0 = _leafCommitment(idtimestampBe, g0);
         bytes32[] memory accMem0 = _toAcc(leaf0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceiptES256(accMem0, es256Pk);
         vm.prank(BOOTSTRAP);
         Univocity es256Univocity =
@@ -1372,7 +1372,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         es256Univocity.publishCheckpoint(
             consistency0, _emptyInclusionProof(), idtimestampBe, g0
         );
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -1382,7 +1382,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf1 = _leafCommitment(IDTIMESTAMP_AUTH, g1);
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(leaf0, leaf1);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1405,7 +1405,7 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
     function test_publishCheckpoint_revertsWhenConsistencyReceiptInvalidCose()
         public
     {
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -1414,9 +1414,8 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
             AUTHORITY_LOG_ID,
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 1,
             paths: new bytes32[][](0),
@@ -1428,19 +1427,18 @@ contract UnivocityTest is UnivocityTestHelper, IUnivocityEvents {
         );
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        IUnivocity.ConsistencyReceipt memory invalidReceipt =
-            IUnivocity.ConsistencyReceipt({
-                protectedHeader: hex"a1013a00010106",
-                signature: abi.encodePacked(r, s, v),
-                consistencyProofs: proofs,
-                delegationProof: IUnivocity.DelegationProof({
-                    delegationKey: "",
-                    mmrStart: 0,
-                    mmrEnd: 0,
-                    alg: 0,
-                    signature: ""
-                })
-            });
+        ConsistencyReceipt memory invalidReceipt = ConsistencyReceipt({
+            protectedHeader: hex"a1013a00010106",
+            signature: abi.encodePacked(r, s, v),
+            consistencyProofs: proofs,
+            delegationProof: DelegationProof({
+                delegationKey: "",
+                mmrStart: 0,
+                mmrEnd: 0,
+                alg: 0,
+                signature: ""
+            })
+        });
         vm.expectRevert(
             abi.encodeWithSelector(
                 IUnivocityErrors.InvalidAccumulatorLength.selector,

--- a/test/checkpoints/UnivocityBootstrap.t.sol
+++ b/test/checkpoints/UnivocityBootstrap.t.sol
@@ -8,6 +8,10 @@ pragma solidity ^0.8.24;
 import "./UnivocityTestHelper.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyReceipt,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 
 contract UnivocityBootstrapTest is UnivocityTestHelper {
     function setUp() public override {
@@ -20,7 +24,7 @@ contract UnivocityBootstrapTest is UnivocityTestHelper {
     }
 
     function test_bootstrap_firstCheckpoint_revertsIfSizeZero() public {
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -43,7 +47,7 @@ contract UnivocityBootstrapTest is UnivocityTestHelper {
     }
 
     function test_bootstrap_firstCheckpoint_correctGrant_succeeds() public {
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -53,7 +57,7 @@ contract UnivocityBootstrapTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         univocity.publishCheckpoint(
             consistency, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g

--- a/test/checkpoints/UnivocityBounds.t.sol
+++ b/test/checkpoints/UnivocityBounds.t.sol
@@ -7,6 +7,10 @@ pragma solidity ^0.8.24;
 import "./UnivocityTestHelper.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyReceipt,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 
 contract UnivocityBoundsTest is UnivocityTestHelper {
@@ -24,7 +28,7 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
         bytes32 logId = keccak256("other-target");
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -34,13 +38,13 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
 
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -49,27 +53,26 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             bytes32(0),
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyReceipt memory consistency1 =
-            _buildConsistencyReceipt1To2(
-                leaf0,
-                _leafCommitment(
-                    IDTIMESTAMP_TEST,
-                    _publishGrant(
-                        logId,
-                        GRANT_DATA,
-                        GC_DATA_LOG,
-                        1,
-                        0,
-                        AUTHORITY_LOG_ID,
-                        abi.encodePacked(KS256_SIGNER)
-                    )
+        ConsistencyReceipt memory consistency1 = _buildConsistencyReceipt1To2(
+            leaf0,
+            _leafCommitment(
+                IDTIMESTAMP_TEST,
+                _publishGrant(
+                    logId,
+                    GRANT_DATA,
+                    GC_DATA_LOG,
+                    1,
+                    0,
+                    AUTHORITY_LOG_ID,
+                    abi.encodePacked(KS256_SIGNER)
                 )
-            );
+            )
+        );
         fresh.publishCheckpoint(
             consistency1, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g1
         );
 
-        IUnivocity.PublishGrant memory grantEnd1 = _publishGrant(
+        PublishGrant memory grantEnd1 = _publishGrant(
             logId,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -85,10 +88,9 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             fresh, keccak256("peak1"), logId, grantEnd1, leaf1, pathForRoi
         );
 
-        IUnivocity.ConsistencyReceipt memory consistency1to3 =
-            _buildConsistencyReceipt1To3(
-                keccak256("peak1"), leaf1, keccak256("leaf2")
-            );
+        ConsistencyReceipt memory consistency1to3 = _buildConsistencyReceipt1To3(
+            keccak256("peak1"), leaf1, keccak256("leaf2")
+        );
         vm.expectRevert(
             abi.encodeWithSelector(
                 IUnivocityErrors.MaxHeightExceeded.selector,
@@ -109,7 +111,7 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -119,12 +121,12 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -133,7 +135,7 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             bytes32(0),
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(leaf0, authorityLeaf1);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -155,12 +157,11 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
         );
         assertEq(univocity.logState(TEST_LOG_ID).size, 1);
 
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
-            _buildConsistencyReceipt1To2(
-                keccak256("peak1"), keccak256("leaf2")
-            );
+        ConsistencyReceipt memory consistency1to2 = _buildConsistencyReceipt1To2(
+            keccak256("peak1"), keccak256("leaf2")
+        );
         bytes32[] memory path = _path1(authorityLeaf0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID, GRANT_DATA, GC_DATA_LOG, 10, 2, AUTHORITY_LOG_ID, ""
         );
         vm.expectRevert(
@@ -184,7 +185,7 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
     function test_rule4_grantExhausted_whenSizeReachesMaxHeight() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -194,12 +195,12 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -209,9 +210,9 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf1 = _leafCommitment(IDTIMESTAMP_TEST, g);
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(leaf0, leaf1);
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -228,14 +229,14 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
         bytes32 leaf2 = keccak256("leaf2");
         bytes32 leaf3 = keccak256("leaf3");
         bytes32[] memory path = _path1(leaf0);
-        IUnivocity.ConsistencyReceipt memory receipt1 =
+        ConsistencyReceipt memory receipt1 =
             _buildConsistencyReceipt(_toAcc(peak1));
         fresh.publishCheckpoint(
             receipt1, _buildPaymentInclusionProof(1, path), IDTIMESTAMP_TEST, g
         );
         assertEq(fresh.logState(TEST_LOG_ID).size, 1);
 
-        IUnivocity.ConsistencyReceipt memory consistency1to2Data =
+        ConsistencyReceipt memory consistency1to2Data =
             _buildConsistencyReceipt1To2(peak1, leaf2);
         fresh.publishCheckpoint(
             consistency1to2Data,
@@ -245,7 +246,7 @@ contract UnivocityBoundsTest is UnivocityTestHelper {
         );
         assertEq(fresh.logState(TEST_LOG_ID).size, 2);
 
-        IUnivocity.ConsistencyReceipt memory consistency2to3 =
+        ConsistencyReceipt memory consistency2to3 =
             _buildConsistencyReceipt2To3(peak1, leaf2, leaf3);
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/checkpoints/UnivocityExtend.t.sol
+++ b/test/checkpoints/UnivocityExtend.t.sol
@@ -7,6 +7,10 @@ pragma solidity ^0.8.24;
 import "./UnivocityTestHelper.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyReceipt,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 
 contract UnivocityExtendTest is UnivocityTestHelper {
@@ -19,7 +23,7 @@ contract UnivocityExtendTest is UnivocityTestHelper {
     function test_firstCheckpoint_sizeTwo_succeeds() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -29,12 +33,12 @@ contract UnivocityExtendTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -44,7 +48,7 @@ contract UnivocityExtendTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf1 = _leafCommitment(IDTIMESTAMP_TEST, g1);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(leaf0, leaf1);
         fresh.publishCheckpoint(
             consistency1, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
@@ -59,11 +63,10 @@ contract UnivocityExtendTest is UnivocityTestHelper {
     function test_publishCheckpoint_authorityLogSecondCheckpoint_requiresInclusionProof()
         public
     {
-        IUnivocity.ConsistencyReceipt memory consistency2 =
-            _buildConsistencyReceipt2To3(
-                authorityLeaf0, authorityLeaf1, keccak256("extra")
-            );
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        ConsistencyReceipt memory consistency2 = _buildConsistencyReceipt2To3(
+            authorityLeaf0, authorityLeaf1, keccak256("extra")
+        );
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -86,11 +89,11 @@ contract UnivocityExtendTest is UnivocityTestHelper {
     function test_publishCheckpoint_bootstrapCanPublishToAuthorityLog()
         public
     {
-        IUnivocity.ConsistencyReceipt memory consistency2 =
+        ConsistencyReceipt memory consistency2 =
             _buildConsistencyReceipt2To3(
                 authorityLeaf0, authorityLeaf1, keccak256("third")
             );
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -129,12 +132,11 @@ contract UnivocityExtendTest is UnivocityTestHelper {
         uint256 sizeBefore = univocity.logState(TEST_LOG_ID).size;
         assertEq(sizeBefore, 1);
 
-        IUnivocity.ConsistencyReceipt memory consistency1to3 =
-            _buildConsistencyReceipt1To3(
-                keccak256("peak1"), authorityLeaf1, keccak256("leaf2")
-            );
+        ConsistencyReceipt memory consistency1to3 = _buildConsistencyReceipt1To3(
+            keccak256("peak1"), authorityLeaf1, keccak256("leaf2")
+        );
         bytes32[] memory pathInvalid = _path1(authorityLeaf0);
-        IUnivocity.PublishGrant memory invalidGrant = _publishGrant(
+        PublishGrant memory invalidGrant = _publishGrant(
             TEST_LOG_ID, GRANT_DATA, GC_DATA_LOG, 1, 0, AUTHORITY_LOG_ID, ""
         );
         vm.expectRevert(
@@ -165,7 +167,7 @@ contract UnivocityExtendTest is UnivocityTestHelper {
         bytes32 logId = keccak256("multi-idts");
         bytes8 idt0 = bytes8(0);
         bytes8 idt1 = bytes8(uint64(1));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -175,12 +177,12 @@ contract UnivocityExtendTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(idt0, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(consistency0, _emptyInclusionProof(), idt0, g0);
         assertEq(fresh.rootLogId(), AUTHORITY_LOG_ID);
 
-        IUnivocity.PublishGrant memory g1 = _publishGrant(
+        PublishGrant memory g1 = _publishGrant(
             logId,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -190,11 +192,11 @@ contract UnivocityExtendTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf1 = _leafCommitment(idt1, g1);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(leaf0, leaf1);
         fresh.publishCheckpoint(consistency1, _emptyInclusionProof(), idt0, g0);
 
-        IUnivocity.PublishGrant memory gTarget = _publishGrant(
+        PublishGrant memory gTarget = _publishGrant(
             logId,
             GRANT_DATA,
             GC_DATA_LOG,

--- a/test/checkpoints/UnivocityGrantRequirements.t.sol
+++ b/test/checkpoints/UnivocityGrantRequirements.t.sol
@@ -7,6 +7,10 @@ pragma solidity ^0.8.24;
 import "./UnivocityTestHelper.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyReceipt,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 
 contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
@@ -21,7 +25,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     function test_firstCheckpoint_grantRequirement_wrongCode_reverts() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GF_EXTEND,
             0,
@@ -31,7 +35,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -52,11 +56,11 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID, GF_CREATE | GF_AUTH, 0, 0, 0, bytes32(0), ""
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -75,7 +79,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             AUTHORITY_LOG_ID,
             GF_CREATE | GF_DATA,
             GC_DATA_LOG,
@@ -85,7 +89,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -104,7 +108,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     function test_extendGrant_wrongCode_reverts() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -120,7 +124,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
                 AUTHORITY_LOG_ID, GRANT_ROOT, GC_AUTH_LOG, 0, 0, bytes32(0), ""
             )
         );
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt0To2(leaf0, leaf1);
         fresh.publishCheckpoint(
             consistency0,
@@ -129,9 +133,9 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
             g0
         );
         bytes32 leaf2 = keccak256("third");
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt2To3(leaf0, leaf1, leaf2);
-        IUnivocity.PublishGrant memory gWrong = _publishGrant(
+        PublishGrant memory gWrong = _publishGrant(
             AUTHORITY_LOG_ID,
             GF_CREATE | GF_AUTH,
             GC_AUTH_LOG,
@@ -161,7 +165,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     ///    must be signer key so signature verification runs before grant check.
     function test_newLogGrant_GF_CREATE_required_reverts() public {
         bytes32 newLogId = keccak256("new-data-log");
-        IUnivocity.PublishGrant memory gNoCreate = _publishGrant(
+        PublishGrant memory gNoCreate = _publishGrant(
             newLogId,
             GF_EXTEND | GF_DATA,
             GC_DATA_LOG,
@@ -170,7 +174,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
             AUTHORITY_LOG_ID,
             abi.encodePacked(KS256_SIGNER)
         );
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(keccak256("peak")));
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -193,7 +197,7 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
     function test_extendGrant_GF_EXTEND_required_reverts() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(KS256_SIGNER));
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -203,15 +207,15 @@ contract UnivocityGrantRequirementsTest is UnivocityTestHelper {
             abi.encodePacked(KS256_SIGNER)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_AUTH, g0);
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, g0
         );
         bytes32 leaf1 = keccak256("second");
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(leaf0, leaf1);
-        IUnivocity.PublishGrant memory gNoExtend = _publishGrant(
+        PublishGrant memory gNoExtend = _publishGrant(
             AUTHORITY_LOG_ID,
             GF_CREATE | GF_AUTH,
             GC_AUTH_LOG,

--- a/test/checkpoints/UnivocityStateAndEvents.t.sol
+++ b/test/checkpoints/UnivocityStateAndEvents.t.sol
@@ -8,6 +8,7 @@ import "./UnivocityTestHelper.sol";
 import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
 import {IUnivocityEvents} from "@univocity/interfaces/IUnivocityEvents.sol";
+import {LogConfig, LogKind, LogState} from "@univocity/interfaces/Types.sol";
 
 contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
     function setUp() public override {
@@ -20,14 +21,14 @@ contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
         bytes32 peak1 = keccak256("peak1");
         _publishFirstToTestLog(univocity, peak1, authorityLeaf0, grantTestLog);
 
-        IUnivocity.LogState memory state = univocity.logState(TEST_LOG_ID);
+        LogState memory state = univocity.logState(TEST_LOG_ID);
         assertEq(state.size, 1);
         assertEq(state.accumulator.length, 1);
         assertEq(state.accumulator[0], peak1);
 
-        IUnivocity.LogConfig memory config = univocity.logConfig(TEST_LOG_ID);
+        LogConfig memory config = univocity.logConfig(TEST_LOG_ID);
         assertGt(config.initializedAt, 0);
-        assertEq(uint8(config.kind), uint8(IUnivocity.LogKind.Data));
+        assertEq(uint8(config.kind), uint8(LogKind.Data));
         assertEq(config.authLogId, AUTHORITY_LOG_ID);
     }
 
@@ -57,7 +58,7 @@ contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
             abi.encodePacked(KS256_SIGNER),
             address(this),
             IDTIMESTAMP_TEST,
-            uint8(IUnivocity.LogKind.Data),
+            uint8(LogKind.Data),
             1,
             acc,
             uint64(1),
@@ -77,10 +78,10 @@ contract UnivocityStateAndEventsTest is UnivocityTestHelper, IUnivocityEvents {
 
         bytes32 leaf2 =
             0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50;
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(peak1, leaf2);
         bytes32[] memory path2 = _path1(authorityLeaf0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             TEST_LOG_ID,
             GRANT_DATA,
             GC_DATA_LOG,

--- a/test/checkpoints/UnivocityTestHelper.sol
+++ b/test/checkpoints/UnivocityTestHelper.sol
@@ -34,6 +34,13 @@ import {
     verifyConsistencyProofChain
 } from "@univocity/checkpoints/lib/consistencyReceipt.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyProof,
+    ConsistencyReceipt,
+    DelegationProof,
+    InclusionProof,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {IUnivocityErrors} from "@univocity/interfaces/IUnivocityErrors.sol";
 import {P256} from "@openzeppelin/contracts/utils/cryptography/P256.sol";
 import {consistentRoots} from "@univocity/algorithms/consistentRoots.sol";
@@ -57,7 +64,7 @@ contract ES256RecoveryHelper {
 ///    Test-only: use when you need the key the contract would recover from a
 ///    given receipt (e.g. to align deploy bootstrap with contract recovery).
 contract ES256RecoveredKeyFromReceiptHelper {
-    function getRecoveredKey(IUnivocity.ConsistencyReceipt calldata receipt)
+    function getRecoveredKey(ConsistencyReceipt calldata receipt)
         external
         view
         returns (bytes32 x, bytes32 y)
@@ -72,7 +79,7 @@ contract ES256RecoveredKeyFromReceiptHelper {
     }
 
     /// @notice First peak of first proof (for tests: assert contract sees same).
-    function getFirstPeak(IUnivocity.ConsistencyReceipt calldata receipt)
+    function getFirstPeak(ConsistencyReceipt calldata receipt)
         external
         pure
         returns (bytes32)
@@ -82,7 +89,7 @@ contract ES256RecoveredKeyFromReceiptHelper {
 
     /// @notice Same as contract viewDecodeReceiptAndRecover: run proof chain,
     ///    return first accumulator peak and recovered ES256 key (test-only).
-    function decodeAndRecover(IUnivocity.ConsistencyReceipt calldata receipt)
+    function decodeAndRecover(ConsistencyReceipt calldata receipt)
         external
         view
         returns (bytes32 firstPeak, bytes32 keyX, bytes32 keyY)
@@ -104,10 +111,10 @@ contract ES256RecoveredKeyFromReceiptHelper {
 ///    receipt, ABI decode is aligned and bug is elsewhere.
 contract ES256ReceiptDecodeVerifier {
     function decodeAndRecover(
-        IUnivocity.ConsistencyReceipt calldata consistencyParts,
-        IUnivocity.InclusionProof calldata,
+        ConsistencyReceipt calldata consistencyParts,
+        InclusionProof calldata,
         bytes8,
-        IUnivocity.PublishGrant calldata
+        PublishGrant calldata
     ) external view returns (bytes32 firstPeak, bytes32 keyX, bytes32 keyY) {
         bytes32[] memory initialAcc = new bytes32[](0);
         bytes32[] memory accMem = verifyConsistencyProofChain(
@@ -125,10 +132,10 @@ contract ES256ReceiptDecodeVerifier {
     /// @notice Same 4-arg layout as publishCheckpoint; returns leaf commitment
     ///    so tests can assert grant decodes identically (same leaf as helper).
     function getLeafCommitment(
-        IUnivocity.ConsistencyReceipt calldata,
-        IUnivocity.InclusionProof calldata,
+        ConsistencyReceipt calldata,
+        InclusionProof calldata,
         bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant calldata g
+        PublishGrant calldata g
     ) external pure returns (bytes32) {
         bytes32 inner = sha256(
             abi.encodePacked(
@@ -160,10 +167,10 @@ contract GrantDecodeHarness {
     }
 
     function decodeGrantFourArgs(
-        IUnivocity.ConsistencyReceipt calldata,
-        IUnivocity.InclusionProof calldata,
+        ConsistencyReceipt calldata,
+        InclusionProof calldata,
         bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant calldata g
+        PublishGrant calldata g
     ) external pure returns (DecodedGrant memory out) {
         out.logId = g.logId;
         out.grant = g.grant;
@@ -191,14 +198,12 @@ contract GrantDecodeHarness {
 ///    round-trip yields stable leaf vs 4-arg struct pass.
 contract GrantDecodeHarnessEncoded {
     function decodeGrantEncoded(
-        IUnivocity.ConsistencyReceipt calldata,
-        IUnivocity.InclusionProof calldata,
+        ConsistencyReceipt calldata,
+        InclusionProof calldata,
         bytes8 grantIDTimestampBe,
         bytes calldata encodedGrant
     ) external pure returns (bytes32 leaf) {
-        IUnivocity.PublishGrant memory g = abi.decode(
-            encodedGrant, (IUnivocity.PublishGrant)
-        );
+        PublishGrant memory g = abi.decode(encodedGrant, (PublishGrant));
         bytes32 inner = sha256(
             abi.encodePacked(
                 g.logId,
@@ -263,8 +268,8 @@ abstract contract UnivocityTestHelper is Test {
     ///    authority + second checkpoint (UnivocityTest, Extend, Bounds, etc.).
     bytes32 internal authorityLeaf0;
     bytes32 internal authorityLeaf1;
-    IUnivocity.PublishGrant internal grant1;
-    IUnivocity.PublishGrant internal grantTestLog;
+    PublishGrant internal grant1;
+    PublishGrant internal grantTestLog;
 
     address internal constant BOOTSTRAP = address(0xB007);
     uint256 internal constant SIGNER_PK = 1;
@@ -302,7 +307,7 @@ abstract contract UnivocityTestHelper is Test {
     ///    authority log. Sets authorityLeaf0, authorityLeaf1, grant1,
     ///    grantTestLog. Call after univocity = _deployUnivocityKS256().
     function _publishBootstrapAndSecondCheckpoint() internal {
-        IUnivocity.PublishGrant memory grant0 = _publishGrant(
+        PublishGrant memory grant0 = _publishGrant(
             AUTHORITY_LOG_ID,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -313,7 +318,7 @@ abstract contract UnivocityTestHelper is Test {
         );
         authorityLeaf0 = _leafCommitment(IDTIMESTAMP_AUTH, grant0);
         grant1 = grant0;
-        IUnivocity.ConsistencyReceipt memory consistency0 =
+        ConsistencyReceipt memory consistency0 =
             _buildConsistencyReceipt(_toAcc(authorityLeaf0));
         univocity.publishCheckpoint(
             consistency0, _emptyInclusionProof(), IDTIMESTAMP_AUTH, grant0
@@ -328,7 +333,7 @@ abstract contract UnivocityTestHelper is Test {
             abi.encodePacked(KS256_SIGNER)
         );
         authorityLeaf1 = _leafCommitment(IDTIMESTAMP_TEST, grantTestLog);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(authorityLeaf0, authorityLeaf1);
         vm.prank(BOOTSTRAP);
         univocity.publishCheckpoint(
@@ -336,10 +341,11 @@ abstract contract UnivocityTestHelper is Test {
         );
     }
 
-    function _leafCommitment(
-        bytes8 grantIDTimestampBe,
-        IUnivocity.PublishGrant memory g
-    ) internal pure returns (bytes32) {
+    function _leafCommitment(bytes8 grantIDTimestampBe, PublishGrant memory g)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32 inner = sha256(
             abi.encodePacked(
                 g.logId,
@@ -361,8 +367,8 @@ abstract contract UnivocityTestHelper is Test {
         uint64 minGrowth,
         bytes32 ownerLogId,
         bytes memory grantData
-    ) internal pure returns (IUnivocity.PublishGrant memory) {
-        return IUnivocity.PublishGrant({
+    ) internal pure returns (PublishGrant memory) {
+        return PublishGrant({
             logId: logId,
             grant: grant,
             request: request,
@@ -376,18 +382,17 @@ abstract contract UnivocityTestHelper is Test {
     function _emptyInclusionProof()
         internal
         pure
-        returns (IUnivocity.InclusionProof memory)
+        returns (InclusionProof memory)
     {
-        return IUnivocity.InclusionProof({index: 0, path: new bytes32[](0)});
+        return InclusionProof({index: 0, path: new bytes32[](0)});
     }
 
     function _buildConsistencyReceipt(bytes32[] memory accMem)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
         proofs[0] = _decodedPayload0To1(accMem[0]);
         bytes memory protected = hex"a1013a00010106";
         bytes32 commitment = sha256(abi.encodePacked(accMem));
@@ -395,7 +400,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -406,9 +411,9 @@ abstract contract UnivocityTestHelper is Test {
     function _emptyDelegationProof()
         internal
         pure
-        returns (IUnivocity.DelegationProof memory)
+        returns (DelegationProof memory)
     {
-        return IUnivocity.DelegationProof({
+        return DelegationProof({
             delegationKey: "", mmrStart: 0, mmrEnd: 0, alg: 0, signature: ""
         });
     }
@@ -416,11 +421,10 @@ abstract contract UnivocityTestHelper is Test {
     function _buildConsistencyReceiptSizeZero()
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 0,
             paths: new bytes32[][](0),
@@ -432,7 +436,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -443,11 +447,11 @@ abstract contract UnivocityTestHelper is Test {
     function _decodedPayload0To1(bytes32 peak)
         internal
         pure
-        returns (IUnivocity.ConsistencyProof memory)
+        returns (ConsistencyProof memory)
     {
         bytes32[] memory peaksArr = new bytes32[](1);
         peaksArr[0] = peak;
-        return IUnivocity.ConsistencyProof({
+        return ConsistencyProof({
             treeSize1: 0,
             treeSize2: 1,
             paths: new bytes32[][](0),
@@ -458,7 +462,7 @@ abstract contract UnivocityTestHelper is Test {
     function _buildConsistencyReceipt1To2(bytes32 leaf0, bytes32 leaf1)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
         bytes32 parent = hashPosPair64(3, leaf0, leaf1);
         bytes32[] memory path0 = new bytes32[](1);
@@ -470,9 +474,8 @@ abstract contract UnivocityTestHelper is Test {
         bytes32[] memory toAcc = new bytes32[](2);
         toAcc[0] = parent;
         toAcc[1] = leaf1;
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1,
             treeSize2: 2,
             paths: paths,
@@ -484,7 +487,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -496,7 +499,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         uint256 es256Pk
-    ) internal pure returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal pure returns (ConsistencyReceipt memory) {
         bytes32 parent = hashPosPair64(3, leaf0, leaf1);
         bytes32[] memory path0 = new bytes32[](1);
         path0[0] = leaf1;
@@ -507,9 +510,8 @@ abstract contract UnivocityTestHelper is Test {
         bytes32[] memory toAcc = new bytes32[](2);
         toAcc[0] = parent;
         toAcc[1] = leaf1;
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1,
             treeSize2: 2,
             paths: paths,
@@ -522,7 +524,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 hash = sha256(sigStruct);
         (bytes32 r, bytes32 s) = vm.signP256(es256Pk, hash);
         s = _ensureP256LowerS(s);
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s),
             consistencyProofs: proofs,
@@ -563,14 +565,13 @@ abstract contract UnivocityTestHelper is Test {
     function _buildConsistencyReceipt0To2(bytes32 p0, bytes32 p1)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
         bytes32[] memory toAcc = new bytes32[](2);
         toAcc[0] = hashPosPair64(3, p0, p1);
         toAcc[1] = p1;
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 2,
             paths: new bytes32[][](0),
@@ -582,7 +583,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -594,7 +595,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal returns (ConsistencyReceipt memory) {
         bytes32[] memory path0 = _path2(leaf1, leaf2);
         bytes32[][] memory paths = new bytes32[][](1);
         paths[0] = path0;
@@ -604,9 +605,8 @@ abstract contract UnivocityTestHelper is Test {
         bytes32[] memory emptyRightPeaks = new bytes32[](0);
         bytes32 commitment =
             commitmentHarness.getCommitment(0, paths, emptyRightPeaks);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1,
             treeSize2: 3,
             paths: paths,
@@ -617,7 +617,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -629,16 +629,15 @@ abstract contract UnivocityTestHelper is Test {
         bytes32,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal view returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal view returns (ConsistencyReceipt memory) {
         bytes32[] memory path0 = _path2(leaf1, leaf2);
         bytes32[][] memory paths = new bytes32[][](1);
         paths[0] = path0;
         bytes32[] memory toAcc = new bytes32[](1);
         toAcc[0] =
             includedRootHarness.callIncludedRoot(0, keccak256("leaf0"), path0);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1, treeSize2: 3, paths: paths, rightPeaks: toAcc
         });
         bytes memory protected = hex"a1013a00010106";
@@ -646,7 +645,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes memory sigStruct = buildSigStructure(protected, wrongPayload);
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -658,17 +657,16 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal view returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal view returns (ConsistencyReceipt memory) {
         bytes32 root3 = includedRootHarness.callIncludedRoot(
-            0, leaf0, _path2(leaf1, leaf2)
-        );
+                0, leaf0, _path2(leaf1, leaf2)
+            );
         bytes32 junk = keccak256("junk");
         bytes32[] memory rightPeaksWrong = new bytes32[](2);
         rightPeaksWrong[0] = root3;
         rightPeaksWrong[1] = junk;
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 3,
             paths: new bytes32[][](0),
@@ -680,7 +678,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -692,7 +690,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal returns (ConsistencyReceipt memory) {
         bytes32[] memory pathFromLeaf0 = _path1(leaf2);
         bytes32[][] memory paths = new bytes32[][](1);
         paths[0] = pathFromLeaf0;
@@ -703,9 +701,8 @@ abstract contract UnivocityTestHelper is Test {
         rightPeaks[0] = leaf2;
         bytes32 commitment =
             commitmentHarness.getCommitment(1, paths, rightPeaks);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 2, treeSize2: 3, paths: paths, rightPeaks: rightPeaks
         });
         bytes memory protected = hex"a1013a00010106";
@@ -713,7 +710,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -725,7 +722,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal returns (ConsistencyReceipt memory) {
         bytes32[] memory path0 = _path2(leaf1, leaf2);
         bytes32[] memory path1 = _path2(leaf0, leaf2);
         bytes32[][] memory paths = new bytes32[][](2);
@@ -738,9 +735,8 @@ abstract contract UnivocityTestHelper is Test {
         bytes32[] memory emptyRightPeaks = new bytes32[](0);
         bytes32 commitment =
             commitmentHarness.getCommitment(1, paths, emptyRightPeaks);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 2,
             treeSize2: 3,
             paths: paths,
@@ -751,7 +747,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -763,7 +759,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal returns (ConsistencyReceipt memory) {
         bytes32 parent = hashPosPair64(3, leaf0, leaf1);
         bytes32[] memory path0 = _path2(leaf1, leaf2);
         bytes32[] memory path1 = _path2(parent, leaf2);
@@ -777,9 +773,8 @@ abstract contract UnivocityTestHelper is Test {
         bytes32[] memory emptyRightPeaks = new bytes32[](0);
         bytes32 commitment =
             commitmentHarness.getCommitment(1, paths, emptyRightPeaks);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 2,
             treeSize2: 3,
             paths: paths,
@@ -790,7 +785,7 @@ abstract contract UnivocityTestHelper is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -804,10 +799,10 @@ abstract contract UnivocityTestHelper is Test {
         Univocity u,
         bytes32 onePeak,
         bytes32 authorityLeaf0Val,
-        IUnivocity.PublishGrant memory grantTestLogVal
+        PublishGrant memory grantTestLogVal
     ) internal {
-        IUnivocity.ConsistencyReceipt memory consistency =
-            _buildConsistencyReceipt(_toAcc(onePeak));
+        ConsistencyReceipt memory
+            consistency = _buildConsistencyReceipt(_toAcc(onePeak));
         bytes32[] memory path = _path1(authorityLeaf0Val);
         u.publishCheckpoint(
             consistency,
@@ -823,11 +818,11 @@ abstract contract UnivocityTestHelper is Test {
         Univocity u,
         bytes32 onePeak,
         bytes32, /* logId */
-        IUnivocity.PublishGrant memory grant,
+        PublishGrant memory grant,
         bytes32, /* leafInAuthority */
         bytes32[] memory inclusionPath
     ) internal {
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(onePeak));
         u.publishCheckpoint(
             consistency,
@@ -865,9 +860,9 @@ abstract contract UnivocityTestHelper is Test {
     function _buildPaymentInclusionProof(uint64 index, bytes32[] memory path)
         internal
         pure
-        returns (IUnivocity.InclusionProof memory)
+        returns (InclusionProof memory)
     {
-        return IUnivocity.InclusionProof({index: index, path: path});
+        return InclusionProof({index: index, path: path});
     }
 
     function _buildBootstrapReceiptAndAcc(
@@ -1021,9 +1016,8 @@ abstract contract UnivocityTestHelper is Test {
     function _buildConsistencyReceiptES256(
         bytes32[] memory accMem,
         uint256 es256Pk
-    ) internal pure returns (IUnivocity.ConsistencyReceipt memory) {
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
+    ) internal pure returns (ConsistencyReceipt memory) {
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
         proofs[0] = _decodedPayload0To1(accMem[0]);
         bytes memory protected = hex"a10126";
         bytes32 commitment = sha256(abi.encodePacked(accMem));
@@ -1032,7 +1026,7 @@ abstract contract UnivocityTestHelper is Test {
         bytes32 hash = sha256(sigStruct);
         (bytes32 r, bytes32 s) = vm.signP256(es256Pk, hash);
         s = _ensureP256LowerS(s);
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s),
             consistencyProofs: proofs,

--- a/test/integration/CheckpointFlow.t.sol
+++ b/test/integration/CheckpointFlow.t.sol
@@ -6,6 +6,13 @@ import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {ALG_KS256} from "@univocity/cosecbor/constants.sol";
 import {buildSigStructure} from "@univocity/cosecbor/cosecbor.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyProof,
+    ConsistencyReceipt,
+    DelegationProof,
+    InclusionProof,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {includedRoot} from "@univocity/algorithms/includedRoot.sol";
 import {IUnivocityEvents} from "@univocity/interfaces/IUnivocityEvents.sol";
 import {consistentRoots} from "@univocity/algorithms/consistentRoots.sol";
@@ -85,7 +92,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
     function test_fullFlow_bootstrapInitializesAndPublishesAuthority() public {
         Univocity fresh =
             new Univocity(ALG_KS256, abi.encodePacked(ks256Signer));
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             rootLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -95,7 +102,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             abi.encodePacked(ks256Signer)
         );
         bytes32 leaf0 = _leafCommitment(IDTIMESTAMP_0, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(leaf0));
         fresh.publishCheckpoint(
             consistency, _emptyInclusionProof(), IDTIMESTAMP_0, g
@@ -106,10 +113,11 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
         assertEq(fresh.logState(rootLogId).size, 1);
     }
 
-    function _leafCommitment(
-        bytes8 idtimestampBe,
-        IUnivocity.PublishGrant memory g
-    ) internal pure returns (bytes32) {
+    function _leafCommitment(bytes8 idtimestampBe, PublishGrant memory g)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32 inner = sha256(
             abi.encodePacked(
                 g.logId,
@@ -140,8 +148,8 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
         uint64 minGrowth,
         bytes32 ownerLogId,
         bytes memory grantData
-    ) internal pure returns (IUnivocity.PublishGrant memory) {
-        return IUnivocity.PublishGrant({
+    ) internal pure returns (PublishGrant memory) {
+        return PublishGrant({
             logId: logId,
             grant: grant,
             request: request,
@@ -161,9 +169,9 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
     function _emptyDelegationProof()
         internal
         pure
-        returns (IUnivocity.DelegationProof memory)
+        returns (DelegationProof memory)
     {
-        return IUnivocity.DelegationProof({
+        return DelegationProof({
             delegationKey: "", mmrStart: 0, mmrEnd: 0, alg: 0, signature: ""
         });
     }
@@ -171,27 +179,26 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
     function _emptyInclusionProof()
         internal
         pure
-        returns (IUnivocity.InclusionProof memory)
+        returns (InclusionProof memory)
     {
-        return IUnivocity.InclusionProof({index: 0, path: new bytes32[](0)});
+        return InclusionProof({index: 0, path: new bytes32[](0)});
     }
 
     function _buildPaymentInclusionProof(uint64 index, bytes32[] memory path)
         internal
         pure
-        returns (IUnivocity.InclusionProof memory)
+        returns (InclusionProof memory)
     {
-        return IUnivocity.InclusionProof({index: index, path: path});
+        return InclusionProof({index: index, path: path});
     }
 
     function _buildConsistencyReceipt(bytes32[] memory accMem)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 1,
             paths: new bytes32[][](0),
@@ -203,7 +210,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -213,7 +220,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
 
     function _buildConsistencyReceipt1To2(bytes32 leaf0, bytes32 leaf1)
         internal
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
         bytes32[] memory path0 = new bytes32[](1);
         path0[0] = leaf1;
@@ -226,9 +233,8 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
         commitmentHarness.setAccumulator(accFrom);
         bytes32 commitment =
             commitmentHarness.getCommitment(0, paths, rightPeaksOnly);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1,
             treeSize2: 2,
             paths: paths,
@@ -239,7 +245,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -391,7 +397,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
     }
 
     function test_fullFlow_userCheckpointsWithReceipt() public {
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             rootLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -408,7 +414,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             g0
         );
 
-        IUnivocity.PublishGrant memory gTarget = _publishGrant(
+        PublishGrant memory gTarget = _publishGrant(
             TARGET_LOG,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -418,7 +424,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             abi.encodePacked(ks256Signer)
         );
         bytes32 targetLeaf = _leafCommitment(IDTIMESTAMP_1, gTarget);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(authLeaf0, targetLeaf);
         vm.prank(BOOTSTRAP);
         univocity.publishCheckpoint(
@@ -439,7 +445,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
     }
 
     function test_fullFlow_sameReceiptDifferentSubmitters() public {
-        IUnivocity.PublishGrant memory g0 = _publishGrant(
+        PublishGrant memory g0 = _publishGrant(
             rootLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -456,7 +462,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             g0
         );
 
-        IUnivocity.PublishGrant memory gTarget = _publishGrant(
+        PublishGrant memory gTarget = _publishGrant(
             TARGET_LOG,
             GRANT_DATA,
             GC_DATA_LOG,
@@ -466,7 +472,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             abi.encodePacked(ks256Signer)
         );
         bytes32 targetLeaf = _leafCommitment(IDTIMESTAMP_1, gTarget);
-        IUnivocity.ConsistencyReceipt memory consistency1 =
+        ConsistencyReceipt memory consistency1 =
             _buildConsistencyReceipt1To2(authLeaf0, targetLeaf);
         vm.prank(BOOTSTRAP);
         univocity.publishCheckpoint(
@@ -486,7 +492,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
 
         bytes32 leaf2 =
             0xcd2662154e6d76b2b2b92e70c0cac3ccf534f9b74eb5b89819ec509083d00a50;
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(peak1, leaf2);
         vm.prank(address(0xB0b));
         univocity.publishCheckpoint(
@@ -503,7 +509,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
         bytes32 leaf0,
         bytes32 leaf1,
         bytes32 leaf2
-    ) internal returns (IUnivocity.ConsistencyReceipt memory) {
+    ) internal returns (ConsistencyReceipt memory) {
         bytes32[] memory path0 = _path2(leaf1, leaf2);
         bytes32[][] memory paths = new bytes32[][](1);
         paths[0] = path0;
@@ -513,9 +519,8 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
         bytes32[] memory emptyRightPeaks = new bytes32[](0);
         bytes32 commitment =
             commitmentHarness.getCommitment(0, paths, emptyRightPeaks);
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1,
             treeSize2: 3,
             paths: paths,
@@ -526,7 +531,7 @@ contract CheckpointFlowTest is Test, IUnivocityEvents {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,

--- a/test/invariants/Univocity.invariants.sol
+++ b/test/invariants/Univocity.invariants.sol
@@ -6,6 +6,14 @@ import {Univocity} from "@univocity/contracts/Univocity.sol";
 import {ALG_KS256} from "@univocity/cosecbor/constants.sol";
 import {buildSigStructure} from "@univocity/cosecbor/cosecbor.sol";
 import {IUnivocity} from "@univocity/interfaces/IUnivocity.sol";
+import {
+    ConsistencyProof,
+    ConsistencyReceipt,
+    DelegationProof,
+    InclusionProof,
+    LogState,
+    PublishGrant
+} from "@univocity/interfaces/Types.sol";
 import {hashPosPair64} from "@univocity/algorithms/binUtils.sol";
 import {peaks} from "@univocity/algorithms/peaks.sol";
 
@@ -34,7 +42,7 @@ contract UnivocityHandler is Test {
     function initialize() external {
         if (initialized) return;
         bytes8 idts = bytes8(0);
-        IUnivocity.PublishGrant memory g = _publishGrant(
+        PublishGrant memory g = _publishGrant(
             rootLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -44,7 +52,7 @@ contract UnivocityHandler is Test {
             abi.encodePacked(ks256Signer)
         );
         _authorityLeaf0 = _leafCommitment(idts, g);
-        IUnivocity.ConsistencyReceipt memory consistency =
+        ConsistencyReceipt memory consistency =
             _buildConsistencyReceipt(_toAcc(_authorityLeaf0));
         univocity.publishCheckpoint(
             consistency, _emptyInclusionProof(), idts, g
@@ -52,10 +60,11 @@ contract UnivocityHandler is Test {
         initialized = true;
     }
 
-    function _leafCommitment(
-        bytes8 idtimestampBe,
-        IUnivocity.PublishGrant memory g
-    ) internal pure returns (bytes32) {
+    function _leafCommitment(bytes8 idtimestampBe, PublishGrant memory g)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32 inner = sha256(
             abi.encodePacked(
                 g.logId,
@@ -86,8 +95,8 @@ contract UnivocityHandler is Test {
         uint64 minGrowth,
         bytes32 ownerLogId,
         bytes memory grantData
-    ) internal pure returns (IUnivocity.PublishGrant memory) {
-        return IUnivocity.PublishGrant({
+    ) internal pure returns (PublishGrant memory) {
+        return PublishGrant({
             logId: logId,
             grant: grant,
             request: request,
@@ -107,9 +116,9 @@ contract UnivocityHandler is Test {
     function _emptyDelegationProof()
         internal
         pure
-        returns (IUnivocity.DelegationProof memory)
+        returns (DelegationProof memory)
     {
-        return IUnivocity.DelegationProof({
+        return DelegationProof({
             delegationKey: "", mmrStart: 0, mmrEnd: 0, alg: 0, signature: ""
         });
     }
@@ -117,19 +126,18 @@ contract UnivocityHandler is Test {
     function _emptyInclusionProof()
         internal
         pure
-        returns (IUnivocity.InclusionProof memory)
+        returns (InclusionProof memory)
     {
-        return IUnivocity.InclusionProof({index: 0, path: new bytes32[](0)});
+        return InclusionProof({index: 0, path: new bytes32[](0)});
     }
 
     function _buildConsistencyReceipt(bytes32[] memory accMem)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 0,
             treeSize2: 1,
             paths: new bytes32[][](0),
@@ -141,7 +149,7 @@ contract UnivocityHandler is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -225,7 +233,7 @@ contract UnivocityHandler is Test {
         if (!initialized) return;
         vm.prank(bootstrap);
         bytes8 idts = bytes8(sizeSeed % 256);
-        IUnivocity.PublishGrant memory gAuth = _publishGrant(
+        PublishGrant memory gAuth = _publishGrant(
             rootLogId,
             GRANT_ROOT,
             GC_AUTH_LOG,
@@ -234,23 +242,23 @@ contract UnivocityHandler is Test {
             bytes32(0),
             abi.encodePacked(ks256Signer)
         );
-        IUnivocity.PublishGrant memory gLog =
+        PublishGrant memory gLog =
             _publishGrant(logId, GRANT_DATA, GC_DATA_LOG, 0, 0, rootLogId, "");
         bytes32 leaf1 = _leafCommitment(idts, gLog);
-        IUnivocity.ConsistencyReceipt memory consistency1to2 =
+        ConsistencyReceipt memory consistency1to2 =
             _buildConsistencyReceipt1To2(_authorityLeaf0, leaf1);
         univocity.publishCheckpoint(
             consistency1to2, _emptyInclusionProof(), bytes8(0), gAuth
         );
 
-        IUnivocity.LogState memory s = univocity.logState(rootLogId);
+        LogState memory s = univocity.logState(rootLogId);
         ghost_lastSize[rootLogId] = s.size;
     }
 
     function _buildConsistencyReceipt1To2(bytes32 leaf0, bytes32 leaf1)
         internal
         pure
-        returns (IUnivocity.ConsistencyReceipt memory)
+        returns (ConsistencyReceipt memory)
     {
         bytes32 parent = hashPosPair64(3, leaf0, leaf1);
         bytes32[] memory path0 = new bytes32[](1);
@@ -260,9 +268,8 @@ contract UnivocityHandler is Test {
         bytes32[] memory toAcc = new bytes32[](2);
         toAcc[0] = parent;
         toAcc[1] = leaf1;
-        IUnivocity.ConsistencyProof[] memory proofs =
-            new IUnivocity.ConsistencyProof[](1);
-        proofs[0] = IUnivocity.ConsistencyProof({
+        ConsistencyProof[] memory proofs = new ConsistencyProof[](1);
+        proofs[0] = ConsistencyProof({
             treeSize1: 1, treeSize2: 2, paths: paths, rightPeaks: toAcc
         });
         bytes memory protected = hex"a1013a00010106";
@@ -271,7 +278,7 @@ contract UnivocityHandler is Test {
             buildSigStructure(protected, abi.encodePacked(commitment));
         (uint8 v, bytes32 r, bytes32 s) =
             vm.sign(SIGNER_PK, keccak256(sigStruct));
-        return IUnivocity.ConsistencyReceipt({
+        return ConsistencyReceipt({
             protectedHeader: protected,
             signature: abi.encodePacked(r, s, v),
             consistencyProofs: proofs,
@@ -328,7 +335,7 @@ contract UnivocityInvariantTest is Test {
         for (uint256 i = 0; i < logIds.length; i++) {
             bytes32 id = logIds[i];
             if (!handler.univocity().isLogInitialized(id)) continue;
-            IUnivocity.LogState memory s = handler.univocity().logState(id);
+            LogState memory s = handler.univocity().logState(id);
             uint256 expectedPeaks =
                 s.size == 0 ? 0 : peaks(uint256(s.size) - 1).length;
             assertEq(


### PR DESCRIPTION
- Add src/interfaces/Types.sol with file-scope LogKind, LogConfig, LogState,
  ConsistencyProof, InclusionProof, DelegationProof, ConsistencyReceipt,
  PublishGrant (no interface or library).
- Add IUnivocal.sol in interfaces/.
- Update IUnivocity, IUnivocal, Univocity, consistencyReceipt, and all tests
  to import from @univocity/interfaces/Types.sol.
- Remove src/UnivocityTypes.sol (replaced by interfaces/Types.sol).

Made with [Cursor](https://cursor.com)