### PR TITLE
chore: use Foundry 1.5.1 in CI and mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "v1.4.3"
+          version: "v1.5.1"
 
       - name: Show Forge version
         run: forge --version

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@ doppler = "3.75.3"
 # uv for venv and pip (taskfile uses uv venv + uv pip install slither-analyzer)
 uv = "latest"
 # Foundry: forge, cast, anvil, chisel (pin to match CI .github/workflows/test.yml)
-foundry = "1.4.3"
+foundry = "1.5.1"
 # Slither static analyzer (pipx install; use: slither --fail-low src or mise run slither-check)
 "pipx:slither-analyzer" = "latest"
 

--- a/src/contracts/_Univocity.sol
+++ b/src/contracts/_Univocity.sol
@@ -169,9 +169,8 @@ abstract contract _Univocity is IUnivocity, IUnivocityErrors {
         // before running the consistency proof chain.
         uint64 claimedSize =
             consistencyParts.consistencyProofs[
-            consistencyParts.consistencyProofs.length - 1
-        ]
-        .treeSize2;
+                consistencyParts.consistencyProofs.length - 1
+            ].treeSize2;
 
         // New log must have at least one leaf; reject claimed size 0.
         if (config.initializedAt == 0 && claimedSize == 0) {


### PR DESCRIPTION
## Summary

Align CI and local tooling on **Foundry 1.5.1**.

## Changes

- **.github/workflows/test.yml** — Bump Foundry toolchain from `v1.4.3` to `v1.5.1`.
- **mise.toml** — Pin `foundry` from `1.4.3` to `1.5.1` so local `forge fmt` / `forge test` match CI.
- **src/contracts/_Univocity.sol** — Reformat with `forge fmt` (1.5.1) so `forge fmt --check` passes with the new version.

## Verification

- `FOUNDRY_PROFILE=ci forge fmt --check` — pass
- `FOUNDRY_PROFILE=ci forge test` — 220 tests pass

Made with [Cursor](https://cursor.com)