### PR TITLE
docs(agents): Foundry PATH and Go toolchain note for cloud VMs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,13 @@ web server or backend service to run — all development tasks are
 ### Environment notes
 
 - **Foundry v1.5.1** is pinned (must match CI). Install via
-  `foundryup --install v1.5.1`. The binaries live in
-  `~/.foundry/bin`; ensure this is on `PATH`.
+ `foundryup --install v1.5.1`. The binaries live in
+ `~/.foundry/bin`; ensure this is on `PATH` (Cloud VMs: add to
+ `~/.bashrc` if not already present).
+- **Go 1.24.4+** is required only for the separate `go-univocity`
+ repo; set `GOTOOLCHAIN=go1.24.4` (or install via
+ `go install golang.org/dl/go1.24.4@latest && go1.24.4 download`).
+ This Solidity repo does not need Go for `forge test`.
 - **Git submodules** supply all Solidity library dependencies
   (`lib/forge-std`, `lib/openzeppelin-contracts`, `lib/solmate`,
   `lib/witnet-solidity-bridge`). Submodules are managed exclusively


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Clarifies Cloud Agent VM setup:

- Add `~/.foundry/bin` to PATH in bashrc when needed.
- Note that Go 1.24.4+ is for the separate `go-univocity` repo only; Solidity work remains `forge` commands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-919b0d3d-4bb2-403d-95df-584046a1fb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-919b0d3d-4bb2-403d-95df-584046a1fb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

