### PR TITLE
feat(deploy): foundry-free deploy manifest and Safe taskfile (FOR-148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Forge tests
         run: forge test -vvv
 
+      - name: Deploy manifest generator tests
+        run: python3 -m unittest scripts/test_generate_deploy_manifest.py scripts/test_verify_deploy_manifest_artifact.py
+
       - name: Install mise
         uses: jdx/mise-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,17 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF#refs/tags/}"
           python3 scripts/generate_deploy_manifest.py "${TAG}" --out-dir out \
+            --create3-out-dir script/create3-factory/out \
             --output "deploy-manifest-${TAG}.json"
+
+      - name: Verify deploy manifest matches artifact
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          python3 scripts/verify_deploy_manifest_artifact.py \
+            "deploy-manifest-${TAG}.json" \
+            out/ImutableUnivocity.sol/ImutableUnivocity.json
 
       - name: Prepare release assets
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,25 @@ jobs:
           UNIVOCITY_TOOLS_VERSION: ${{ inputs.tools_version || 'v0.4.0' }}
         run: task contract-artefacts-release:release
 
+      - name: Generate deploy manifest
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          python3 scripts/generate_deploy_manifest.py "${TAG}" --out-dir out \
+            --output "deploy-manifest-${TAG}.json"
+
       - name: Prepare release assets
         run: |
           set -euo pipefail
           mkdir -p release
           cp .work/univocity-*.tar.gz .work/create3-factory-*.tar.gz release/
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ -f "deploy-manifest-${TAG}.json" ]; then
+            cp "deploy-manifest-${TAG}.json" release/
+            ( cd release && shasum -a 256 "deploy-manifest-${TAG}.json" \
+              > "deploy-manifest-${TAG}.json.sha256" )
+          fi
           for asset in release/*.tar.gz; do
             ( cd release && shasum -a 256 "$(basename "$asset")" > "$(basename "$asset").sha256" )
           done
@@ -81,3 +95,5 @@ jobs:
           files: |
             release/*.tar.gz
             release/*.tar.gz.sha256
+            release/deploy-manifest-*.json
+            release/deploy-manifest-*.json.sha256

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ re-initialization.
 
 ## Deployment
 
+### Consumer deploy (no Foundry required)
+
+Independent operators can deploy **ImutableUnivocity** from a published release
+using the prebuilt [univocity-tools deployer](https://github.com/forestrie/univocity-tools/releases)
+binary — no `forge`, `cast`, or clone of this repo.
+
+1. Download `deployer-linux-x64` or `deployer-darwin-arm64` (+ `.sha256`) from
+   an [univocity-tools release](https://github.com/forestrie/univocity-tools/releases).
+2. One-shot EOA deploy (uses `deploy-manifest-<tag>.json` when present):
+
+```shell
+./deployer-darwin-arm64 deploy imutable \
+  --from-release v0.4.0 \
+  --bootstrap-alg ks256 \
+  --bootstrap-ks256-signer 0xYourSigner \
+  --deploy-key "$DEPLOY_KEY" \
+  --rpc-url "$RPC_URL"
+```
+
+Multi-step flows (`deploy propose imutable --from-manifest`, `--release-root`,
+`deploy execute`) are documented in
+[univocity-tools CLI docs](https://github.com/forestrie/univocity-tools/blob/main/docs/agents/cli.md).
+
+Foundry remains required for **contract development** and for producing release
+archives in CI.
+
+### Developer deploy (from source)
+
 **ImutableUnivocity (non-upgradeable):** Set `KS256_SIGNER` or `ES256_X`/`ES256_Y`,
 then `forge script script/Deploy.s.sol --rpc-url <RPC> --broadcast`.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ binary — no `forge`, `cast`, or clone of this repo.
 Multi-step flows (`deploy propose imutable --from-manifest`, `--release-root`,
 `deploy execute`) are documented in
 [univocity-tools CLI docs](https://github.com/forestrie/univocity-tools/blob/main/docs/agents/cli.md).
+Manifest schema and trust model:
+[ADR-0010](https://github.com/forestrie/univocity-tools/blob/main/docs/adr/adr-0010-deploy-manifest-format.md).
+
+Safe path via taskfile: `task imutable-deploy:default SALT=0x…` (see
+`taskfiles/imutable-deploy.yml`).
 
 Foundry remains required for **contract development** and for producing release
 archives in CI.

--- a/scripts/generate-deploy-manifest.sh
+++ b/scripts/generate-deploy-manifest.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Shell wrapper for generate-deploy-manifest.py (release CI).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_ID="${1:?release id required}"
+python3 "${ROOT}/scripts/generate_deploy_manifest.py" "${RELEASE_ID}" "${@:2}"

--- a/scripts/generate_deploy_manifest.py
+++ b/scripts/generate_deploy_manifest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Generate deploy-manifest-<release-id>.json from forge out/ artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def bytecode_sha256(hex_bytecode: str) -> str:
+    raw = bytes.fromhex(hex_bytecode.removeprefix("0x"))
+    return hashlib.sha256(raw).hexdigest()
+
+
+def load_artifact(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must be a JSON object")
+    return data
+
+
+def contract_entry(path: Path) -> dict[str, Any]:
+    artifact = load_artifact(path)
+    bytecode_obj = artifact.get("bytecode")
+    if not isinstance(bytecode_obj, dict):
+        raise ValueError(f"{path} missing bytecode object")
+    creation = bytecode_obj.get("object")
+    if not isinstance(creation, str) or not creation.startswith("0x"):
+        raise ValueError(f"{path} missing bytecode.object hex")
+
+    contract_name = path.stem
+    metadata_raw = artifact.get("metadata")
+    solc_version = "unknown"
+    if isinstance(metadata_raw, str):
+        try:
+            metadata = json.loads(metadata_raw)
+            compiler = metadata.get("compiler")
+            if isinstance(compiler, dict):
+                version = compiler.get("version")
+                if isinstance(version, str):
+                    solc_version = version
+        except json.JSONDecodeError:
+            pass
+
+    abi = artifact.get("abi")
+    constructor_abi: list[Any] = []
+    if isinstance(abi, list):
+        constructor_abi = [
+            item for item in abi if isinstance(item, dict) and item.get("type") == "constructor"
+        ]
+
+    entry: dict[str, Any] = {
+        "contractName": contract_name,
+        "creationBytecode": creation,
+        "bytecodeSha256": bytecode_sha256(creation),
+        "solcVersion": solc_version,
+    }
+    if constructor_abi:
+        entry["constructorAbi"] = constructor_abi
+    return entry
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("release_id", help="Release tag, e.g. v0.4.0")
+    parser.add_argument(
+        "--out-dir",
+        default="out",
+        help="Foundry out directory (default: out)",
+    )
+    parser.add_argument(
+        "--output",
+        help="Output path (default: deploy-manifest-<release_id>.json)",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    imutable_path = out_dir / "ImutableUnivocity.sol" / "ImutableUnivocity.json"
+    if not imutable_path.is_file():
+        raise SystemExit(f"missing artifact: {imutable_path}")
+
+    contracts: dict[str, Any] = {
+        "ImutableUnivocity": contract_entry(imutable_path),
+    }
+
+    factory_path = out_dir / "CREATE3Factory.sol" / "CREATE3Factory.json"
+    if factory_path.is_file():
+        contracts["CREATE3Factory"] = contract_entry(factory_path)
+
+    manifest = {
+        "version": 1,
+        "releaseId": args.release_id,
+        "contracts": contracts,
+    }
+
+    output = Path(args.output or f"deploy-manifest-{args.release_id}.json")
+    output.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_deploy_manifest.py
+++ b/scripts/generate_deploy_manifest.py
@@ -65,7 +65,7 @@ def contract_entry(path: Path) -> dict[str, Any]:
     return entry
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("release_id", help="Release tag, e.g. v0.4.0")
     parser.add_argument(
@@ -77,7 +77,7 @@ def main() -> int:
         "--output",
         help="Output path (default: deploy-manifest-<release_id>.json)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     out_dir = Path(args.out_dir)
     imutable_path = out_dir / "ImutableUnivocity.sol" / "ImutableUnivocity.json"

--- a/scripts/generate_deploy_manifest.py
+++ b/scripts/generate_deploy_manifest.py
@@ -71,7 +71,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--out-dir",
         default="out",
-        help="Foundry out directory (default: out)",
+        help="Foundry out directory for ImutableUnivocity (default: out)",
+    )
+    parser.add_argument(
+        "--create3-out-dir",
+        default="script/create3-factory/out",
+        help="Foundry out directory for CREATE3Factory "
+        "(default: script/create3-factory/out)",
     )
     parser.add_argument(
         "--output",
@@ -88,7 +94,7 @@ def main(argv: list[str] | None = None) -> int:
         "ImutableUnivocity": contract_entry(imutable_path),
     }
 
-    factory_path = out_dir / "CREATE3Factory.sol" / "CREATE3Factory.json"
+    factory_path = Path(args.create3_out_dir) / "CREATE3Factory.sol" / "CREATE3Factory.json"
     if factory_path.is_file():
         contracts["CREATE3Factory"] = contract_entry(factory_path)
 

--- a/scripts/test_generate_deploy_manifest.py
+++ b/scripts/test_generate_deploy_manifest.py
@@ -10,13 +10,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from generate_deploy_manifest import bytecode_sha256, contract_entry
+from generate_deploy_manifest import bytecode_sha256, contract_entry, main
 
 
 class GenerateDeployManifestTest(unittest.TestCase):
     def test_bytecode_sha256_known_vector(self) -> None:
         digest = bytecode_sha256("0x6001")
         self.assertEqual(len(digest), 64)
+        self.assertEqual(
+            digest,
+            "9e67b12fd8c58953460459cad7a6d4dd7d6d57594affce8206d1397c9c4db543",
+        )
 
     def test_contract_entry_from_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -39,6 +43,62 @@ class GenerateDeployManifestTest(unittest.TestCase):
             self.assertEqual(entry["creationBytecode"], bytecode)
             self.assertEqual(entry["bytecodeSha256"], bytecode_sha256(bytecode))
             self.assertEqual(entry["solcVersion"], "0.8.26+commit.abc")
+
+    def test_main_matches_golden_fixture_shape(self) -> None:
+        golden_path = (
+            Path(__file__).resolve().parent.parent
+            / "test"
+            / "fixtures"
+            / "deploy-manifest.fixture.json"
+        )
+        golden = json.loads(golden_path.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "out"
+            artifact_dir = out_dir / "ImutableUnivocity.sol"
+            artifact_dir.mkdir(parents=True)
+            bytecode = golden["contracts"]["ImutableUnivocity"]["creationBytecode"]
+            (artifact_dir / "ImutableUnivocity.json").write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": bytecode},
+                        "metadata": json.dumps(
+                            {
+                                "compiler": {
+                                    "version": golden["contracts"][
+                                        "ImutableUnivocity"
+                                    ]["solcVersion"],
+                                }
+                            }
+                        ),
+                        "abi": golden["contracts"]["ImutableUnivocity"].get(
+                            "constructorAbi", []
+                        ),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = Path(tmp) / "deploy-manifest-v0.4.0-fixture.json"
+            rc = main(
+                [
+                    "v0.4.0-fixture",
+                    "--out-dir",
+                    str(out_dir),
+                    "--output",
+                    str(output),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            generated = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(generated["version"], golden["version"])
+            self.assertEqual(generated["releaseId"], golden["releaseId"])
+            imutable = generated["contracts"]["ImutableUnivocity"]
+            golden_imutable = golden["contracts"]["ImutableUnivocity"]
+            self.assertEqual(
+                imutable["creationBytecode"], golden_imutable["creationBytecode"]
+            )
+            self.assertEqual(
+                imutable["bytecodeSha256"], golden_imutable["bytecodeSha256"]
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_generate_deploy_manifest.py
+++ b/scripts/test_generate_deploy_manifest.py
@@ -1,0 +1,45 @@
+"""Tests for scripts/generate_deploy_manifest.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from generate_deploy_manifest import bytecode_sha256, contract_entry
+
+
+class GenerateDeployManifestTest(unittest.TestCase):
+    def test_bytecode_sha256_known_vector(self) -> None:
+        digest = bytecode_sha256("0x6001")
+        self.assertEqual(len(digest), 64)
+
+    def test_contract_entry_from_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ImutableUnivocity.json"
+            bytecode = "0x6001"
+            path.write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": bytecode},
+                        "metadata": json.dumps(
+                            {"compiler": {"version": "0.8.26+commit.abc"}}
+                        ),
+                        "abi": [{"type": "constructor", "inputs": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            entry = contract_entry(path)
+            self.assertEqual(entry["contractName"], "ImutableUnivocity")
+            self.assertEqual(entry["creationBytecode"], bytecode)
+            self.assertEqual(entry["bytecodeSha256"], bytecode_sha256(bytecode))
+            self.assertEqual(entry["solcVersion"], "0.8.26+commit.abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_deploy_manifest_artifact.py
+++ b/scripts/test_verify_deploy_manifest_artifact.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/verify_deploy_manifest_artifact.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from generate_deploy_manifest import main as generate_main
+from verify_deploy_manifest_artifact import main as verify_main
+
+
+class VerifyDeployManifestArtifactTest(unittest.TestCase):
+    def test_accepts_matching_manifest_and_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "out"
+            artifact_dir = out_dir / "ImutableUnivocity.sol"
+            artifact_dir.mkdir(parents=True)
+            bytecode = "0x6001"
+            (artifact_dir / "ImutableUnivocity.json").write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": bytecode},
+                        "metadata": json.dumps(
+                            {"compiler": {"version": "0.8.26+commit.abc"}}
+                        ),
+                        "abi": [{"type": "constructor", "inputs": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / "deploy-manifest-v0.4.0.json"
+            self.assertEqual(
+                generate_main(
+                    [
+                        "v0.4.0",
+                        "--out-dir",
+                        str(out_dir),
+                        "--output",
+                        str(manifest_path),
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                verify_main(
+                    [
+                        str(manifest_path),
+                        str(artifact_dir / "ImutableUnivocity.json"),
+                    ]
+                ),
+                0,
+            )
+
+    def test_rejects_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest_path = root / "deploy-manifest-v0.4.0.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "releaseId": "v0.4.0",
+                        "contracts": {
+                            "ImutableUnivocity": {
+                                "contractName": "ImutableUnivocity",
+                                "creationBytecode": "0x6001",
+                                "bytecodeSha256": "deadbeef",
+                                "solcVersion": "0.8.26",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            artifact_path = root / "ImutableUnivocity.json"
+            artifact_path.write_text(
+                json.dumps({"bytecode": {"object": "0x6002"}}),
+                encoding="utf-8",
+            )
+            with self.assertRaises(SystemExit):
+                verify_main([str(manifest_path), str(artifact_path)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_deploy_manifest_artifact.py
+++ b/scripts/verify_deploy_manifest_artifact.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Verify deploy-manifest bytecode matches a forge artifact JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from generate_deploy_manifest import bytecode_sha256, contract_entry
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="deploy-manifest JSON path")
+    parser.add_argument(
+        "artifact",
+        type=Path,
+        help="ImutableUnivocity forge artifact JSON path",
+    )
+    args = parser.parse_args(argv)
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    entry = manifest.get("contracts", {}).get("ImutableUnivocity")
+    if not isinstance(entry, dict):
+        raise SystemExit("manifest missing contracts.ImutableUnivocity")
+
+    artifact_entry = contract_entry(args.artifact)
+    for field in ("creationBytecode", "bytecodeSha256"):
+        manifest_value = entry.get(field)
+        artifact_value = artifact_entry.get(field)
+        if manifest_value != artifact_value:
+            raise SystemExit(
+                f"manifest {field} mismatch: manifest={manifest_value!r} "
+                f"artifact={artifact_value!r}",
+            )
+
+    print(f"OK: {args.manifest} matches {args.artifact}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/taskfiles/imutable-deploy.yml
+++ b/taskfiles/imutable-deploy.yml
@@ -1,6 +1,6 @@
 # ImutableUnivocity deploy via univocity-tools deployer (Safe CREATE2 path).
 # Secrets: DEPLOY_KEY, RPC_URL; ES256 also needs BOOTSTRAP_PEM_ES256.
-# Local: doppler run -- task deploy:imutable ALG=es256 SALT=0x…
+# Local: doppler run -- task imutable-deploy:default ALG=es256 SALT=0x…
 version: "3"
 
 vars:
@@ -34,7 +34,17 @@ tasks:
             ;;
         esac
         BIN="{{.DEPLOYER_CACHE_DIR}}/deployer-${PLATFORM}"
+        SIDECAR="${BIN}.sha256"
         if [ -x "$BIN" ]; then
+          if [ ! -f "$SIDECAR" ]; then
+            curl -fsSL "{{.RELEASE_BASE}}/deployer-${PLATFORM}.sha256" -o "$SIDECAR"
+          fi
+          EXPECTED=$(awk '{print $1}' "$SIDECAR")
+          ACTUAL=$(shasum -a 256 "$BIN" | awk '{print $1}')
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "cached deployer sha256 mismatch" >&2
+            exit 1
+          fi
           echo "deployer already present at $BIN"
           echo "$BIN"
           exit 0
@@ -59,19 +69,32 @@ tasks:
       - |
         set -euo pipefail
         MANIFEST="{{.MANIFEST_CACHE_DIR}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json"
+        SIDECAR="${MANIFEST}.sha256"
+        verify_manifest() {
+          if [ ! -f "$SIDECAR" ]; then
+            curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json.sha256" -o "$SIDECAR"
+          fi
+          EXPECTED=$(awk '{print $1}' "$SIDECAR")
+          ACTUAL=$(shasum -a 256 "$MANIFEST" | awk '{print $1}')
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "deploy-manifest sha256 mismatch" >&2
+            exit 1
+          fi
+          RELEASE_ID=$(jq -r '.releaseId' "$MANIFEST")
+          if [ "$RELEASE_ID" != "{{.UNIVOCITY_VERSION}}" ]; then
+            echo "deploy-manifest releaseId mismatch: expected {{.UNIVOCITY_VERSION}}, got ${RELEASE_ID}" >&2
+            exit 1
+          fi
+        }
         if [ -f "$MANIFEST" ]; then
+          verify_manifest
           echo "deploy-manifest already present at $MANIFEST"
           echo "$MANIFEST"
           exit 0
         fi
         curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json" -o "$MANIFEST"
-        curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json.sha256" -o "${MANIFEST}.sha256"
-        EXPECTED=$(awk '{print $1}' "${MANIFEST}.sha256")
-        ACTUAL=$(shasum -a 256 "$MANIFEST" | awk '{print $1}')
-        if [ "$EXPECTED" != "$ACTUAL" ]; then
-          echo "deploy-manifest sha256 mismatch" >&2
-          exit 1
-        fi
+        curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json.sha256" -o "$SIDECAR"
+        verify_manifest
         echo "$MANIFEST"
 
   propose:
@@ -83,13 +106,14 @@ tasks:
       - mkdir -p "{{.PROPOSAL_DIR}}"
       - |
         set -euo pipefail
-        DEPLOYER_BIN="$(task deploy:imutable:deployer:ensure | tail -1)"
-        MANIFEST="$(task deploy:imutable:manifest:ensure | tail -1)"
+        DEPLOYER_BIN="$(task imutable-deploy:deployer:ensure | tail -1)"
+        MANIFEST="$(task imutable-deploy:manifest:ensure | tail -1)"
         PROPOSAL="{{.PROPOSAL_DIR}}/proposal-{{.ALG}}-{{.SALT}}.json"
         "${DEPLOYER_BIN}" deploy propose imutable \
           --source-root "{{.ROOT_DIR}}" \
           --bootstrap-alg "{{.ALG}}" \
           --from-manifest "$MANIFEST" \
+          --manifest-sidecar "${MANIFEST}.sha256" \
           --safe-publish \
           --owner-address "{{.OWNER_ADDRESS}}" \
           --deploy-key "${DEPLOY_KEY:?DEPLOY_KEY is required}" \
@@ -107,10 +131,10 @@ tasks:
     cmds:
       - |
         set -euo pipefail
-        DEPLOYER_BIN="$(task deploy:imutable:deployer:ensure | tail -1)"
+        DEPLOYER_BIN="$(task imutable-deploy:deployer:ensure | tail -1)"
         PROPOSAL="{{.PROPOSAL_DIR}}/proposal-{{.ALG}}-{{.SALT}}.json"
         if [ ! -f "$PROPOSAL" ]; then
-          echo "proposal not found: $PROPOSAL (run deploy:imutable:propose first)" >&2
+          echo "proposal not found: $PROPOSAL (run imutable-deploy:propose first)" >&2
           exit 1
         fi
         "${DEPLOYER_BIN}" deploy approve "$PROPOSAL" \

--- a/taskfiles/imutable-deploy.yml
+++ b/taskfiles/imutable-deploy.yml
@@ -4,8 +4,10 @@
 version: "3"
 
 vars:
-  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.3.0"}}'
+  UNIVOCITY_VERSION: '{{.UNIVOCITY_VERSION | default "v0.4.0"}}'
+  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.4.0"}}'
   DEPLOYER_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-tools"
+  MANIFEST_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-manifest"
   ALG: '{{.ALG | default "es256"}}'
   SALT: "{{.SALT}}"
   OWNER_ADDRESS: '{{.OWNER_ADDRESS | default "0x1528b86ff561f617602356efdbD05908a07AA788"}}'
@@ -48,9 +50,33 @@ tasks:
         chmod +x "$BIN"
         echo "$BIN"
 
+  manifest:ensure:
+    desc: Download deploy-manifest for UNIVOCITY_VERSION and verify sha256 sidecar.
+    vars:
+      RELEASE_BASE: https://github.com/forestrie/univocity/releases/download/{{.UNIVOCITY_VERSION}}
+    cmds:
+      - mkdir -p "{{.MANIFEST_CACHE_DIR}}"
+      - |
+        set -euo pipefail
+        MANIFEST="{{.MANIFEST_CACHE_DIR}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json"
+        if [ -f "$MANIFEST" ]; then
+          echo "deploy-manifest already present at $MANIFEST"
+          echo "$MANIFEST"
+          exit 0
+        fi
+        curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json" -o "$MANIFEST"
+        curl -fsSL "{{.RELEASE_BASE}}/deploy-manifest-{{.UNIVOCITY_VERSION}}.json.sha256" -o "${MANIFEST}.sha256"
+        EXPECTED=$(awk '{print $1}' "${MANIFEST}.sha256")
+        ACTUAL=$(shasum -a 256 "$MANIFEST" | awk '{print $1}')
+        if [ "$EXPECTED" != "$ACTUAL" ]; then
+          echo "deploy-manifest sha256 mismatch" >&2
+          exit 1
+        fi
+        echo "$MANIFEST"
+
   propose:
     desc: Propose ImutableUnivocity via Safe CREATE2 (writes proposal JSON).
-    deps: [deployer:ensure]
+    deps: [deployer:ensure, manifest:ensure]
     requires:
       vars: [SALT]
     cmds:
@@ -58,10 +84,12 @@ tasks:
       - |
         set -euo pipefail
         DEPLOYER_BIN="$(task deploy:imutable:deployer:ensure | tail -1)"
+        MANIFEST="$(task deploy:imutable:manifest:ensure | tail -1)"
         PROPOSAL="{{.PROPOSAL_DIR}}/proposal-{{.ALG}}-{{.SALT}}.json"
         "${DEPLOYER_BIN}" deploy propose imutable \
           --source-root "{{.ROOT_DIR}}" \
           --bootstrap-alg "{{.ALG}}" \
+          --from-manifest "$MANIFEST" \
           --safe-publish \
           --owner-address "{{.OWNER_ADDRESS}}" \
           --deploy-key "${DEPLOY_KEY:?DEPLOY_KEY is required}" \
@@ -100,12 +128,22 @@ tasks:
         set -euo pipefail
         ADDR=$(jq -r '.imutableUnivocity' "{{.MANIFEST}}")
         RPC="${RPC_URL:?RPC_URL is required}"
-        CODE=$(cast code "$ADDR" --rpc-url "$RPC")
-        if [ -z "$CODE" ] || [ "$CODE" = "0x" ]; then
+        CODE=$(curl -fsS "$RPC" \
+          -H 'content-type: application/json' \
+          -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getCode\",\"params\":[\"$ADDR\",\"latest\"]}")
+        BYTECODE=$(echo "$CODE" | jq -r '.result')
+        if [ -z "$BYTECODE" ] || [ "$BYTECODE" = "0x" ]; then
           echo "no contract code at $ADDR" >&2
           exit 1
         fi
-        cast call "$ADDR" "bootstrapConfig()(int64,bytes)" --rpc-url "$RPC" >/dev/null
+        CALL=$(curl -fsS "$RPC" \
+          -H 'content-type: application/json' \
+          -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"eth_call\",\"params\":[{\"to\":\"$ADDR\",\"data\":\"0x198865fe\"},\"latest\"]}")
+        RESULT=$(echo "$CALL" | jq -r '.result')
+        if [ -z "$RESULT" ] || [ "$RESULT" = "0x" ]; then
+          echo "bootstrapConfig call returned empty at $ADDR" >&2
+          exit 1
+        fi
         echo "bootstrapConfig OK at $ADDR"
 
   default:
@@ -135,6 +173,7 @@ tasks:
           --arg salt "$(jq -r '.safe.salt' "$PROPOSAL")" \
           --arg safeTxHash "$(jq -r '.safe.safeTxHash' "$PROPOSAL")" \
           --arg toolsVersion "{{.UNIVOCITY_TOOLS_VERSION}}" \
+          --arg univocityVersion "{{.UNIVOCITY_VERSION}}" \
           '{
             kind: $kind,
             version: $version,
@@ -145,7 +184,8 @@ tasks:
             from: $from,
             salt: $salt,
             safeTxHash: $safeTxHash,
-            toolsVersion: $toolsVersion
+            toolsVersion: $toolsVersion,
+            univocityVersion: $univocityVersion
           }' > "$MANIFEST"
         echo "manifest: $MANIFEST"
         cat "$MANIFEST"

--- a/taskfiles/imutable-deploy.yml
+++ b/taskfiles/imutable-deploy.yml
@@ -6,7 +6,6 @@ version: "3"
 vars:
   UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.3.0"}}'
   DEPLOYER_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-tools"
-  DEPLOYER_BIN: "{{.DEPLOYER_CACHE_DIR}}/deployer-linux-x64"
   ALG: '{{.ALG | default "es256"}}'
   SALT: "{{.SALT}}"
   OWNER_ADDRESS: '{{.OWNER_ADDRESS | default "0x1528b86ff561f617602356efdbD05908a07AA788"}}'
@@ -15,20 +14,31 @@ vars:
 
 tasks:
   deployer:ensure:
-    desc: Download deployer-linux-x64 from univocity-tools GitHub release and verify sha256.
+    desc: Download deployer binary for this OS/arch from univocity-tools release and verify sha256.
     vars:
       RELEASE_BASE: https://github.com/forestrie/univocity-tools/releases/download/{{.UNIVOCITY_TOOLS_VERSION}}
     cmds:
       - mkdir -p "{{.DEPLOYER_CACHE_DIR}}"
       - |
         set -euo pipefail
-        BIN="{{.DEPLOYER_BIN}}"
+        OS="$(uname -s)"
+        ARCH="$(uname -m)"
+        case "${OS}-${ARCH}" in
+          Darwin-arm64) PLATFORM="darwin-arm64" ;;
+          Linux-x86_64|Linux-amd64) PLATFORM="linux-x64" ;;
+          *)
+            echo "unsupported platform: ${OS}-${ARCH}" >&2
+            exit 1
+            ;;
+        esac
+        BIN="{{.DEPLOYER_CACHE_DIR}}/deployer-${PLATFORM}"
         if [ -x "$BIN" ]; then
           echo "deployer already present at $BIN"
+          echo "$BIN"
           exit 0
         fi
-        curl -fsSL "{{.RELEASE_BASE}}/deployer-linux-x64" -o "$BIN"
-        curl -fsSL "{{.RELEASE_BASE}}/deployer-linux-x64.sha256" -o "${BIN}.sha256"
+        curl -fsSL "{{.RELEASE_BASE}}/deployer-${PLATFORM}" -o "$BIN"
+        curl -fsSL "{{.RELEASE_BASE}}/deployer-${PLATFORM}.sha256" -o "${BIN}.sha256"
         EXPECTED=$(awk '{print $1}' "${BIN}.sha256")
         ACTUAL=$(shasum -a 256 "$BIN" | awk '{print $1}')
         if [ "$EXPECTED" != "$ACTUAL" ]; then
@@ -36,6 +46,7 @@ tasks:
           exit 1
         fi
         chmod +x "$BIN"
+        echo "$BIN"
 
   propose:
     desc: Propose ImutableUnivocity via Safe CREATE2 (writes proposal JSON).
@@ -46,8 +57,9 @@ tasks:
       - mkdir -p "{{.PROPOSAL_DIR}}"
       - |
         set -euo pipefail
+        DEPLOYER_BIN="$(task deploy:imutable:deployer:ensure | tail -1)"
         PROPOSAL="{{.PROPOSAL_DIR}}/proposal-{{.ALG}}-{{.SALT}}.json"
-        "{{.DEPLOYER_BIN}}" deploy propose imutable \
+        "${DEPLOYER_BIN}" deploy propose imutable \
           --source-root "{{.ROOT_DIR}}" \
           --bootstrap-alg "{{.ALG}}" \
           --safe-publish \
@@ -67,12 +79,13 @@ tasks:
     cmds:
       - |
         set -euo pipefail
+        DEPLOYER_BIN="$(task deploy:imutable:deployer:ensure | tail -1)"
         PROPOSAL="{{.PROPOSAL_DIR}}/proposal-{{.ALG}}-{{.SALT}}.json"
         if [ ! -f "$PROPOSAL" ]; then
           echo "proposal not found: $PROPOSAL (run deploy:imutable:propose first)" >&2
           exit 1
         fi
-        "{{.DEPLOYER_BIN}}" deploy approve "$PROPOSAL" \
+        "${DEPLOYER_BIN}" deploy approve "$PROPOSAL" \
           --source-root "{{.ROOT_DIR}}" \
           --bootstrap-alg "{{.ALG}}" \
           --deploy-key "${DEPLOY_KEY:?DEPLOY_KEY is required}" \

--- a/test/fixtures/deploy-manifest.fixture.json
+++ b/test/fixtures/deploy-manifest.fixture.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "releaseId": "v0.4.0-fixture",
+  "contracts": {
+    "ImutableUnivocity": {
+      "contractName": "ImutableUnivocity",
+      "creationBytecode": "0x6001",
+      "bytecodeSha256": "9e67b12fd8c58953460459cad7a6d4dd7d6d57594affce8206d1397c9c4db543",
+      "solcVersion": "0.8.26",
+      "constructorAbi": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Tier 1 consumer-side changes for foundry-free ImutableUnivocity deployment
(FOR-148 / FOR-154–157).

- Publish `deploy-manifest.json` as a release asset (FOR-156)
- Platform-select deployer binary download in taskfile (FOR-154)
- Foundry-free Safe taskfile: manifest download + SHA-256 verify,
  `--from-manifest` propose with `--manifest-sidecar`, curl-based verify
- Fixed `imutable-deploy:*` task namespace; cache re-verify + releaseId check
- CI: generator tests + release manifest/artifact cross-check script
- CREATE3Factory output wired into manifest generator

## Merge readiness

- [x] CI green (Foundry project incl. Python tests)
- [x] Mergeable with `main` (no conflicts)
- [x] Remediation review items H4, M1–M3, M6, M8 addressed

**Merge order:** merge after univocity-tools #2, before mandate #8.

## Post-merge

Tag a release (`v*`) so GitHub publishes `deploy-manifest-<tag>.json` and
build archives for `--from-release` consumers.

## Test plan

- [x] `python3 scripts/test_generate_deploy_manifest.py`
- [x] `python3 scripts/test_verify_deploy_manifest_artifact.py`
- [x] CI green on this PR