### PR TITLE
docs(cursor): add agent rules for branches and comments (FOR-179)

### DIFF
--- a/.cursor/rules/branch-naming.mdc
+++ b/.cursor/rules/branch-naming.mdc
@@ -1,0 +1,72 @@
+---
+description: Git branch naming and Linear issue linkage for Forestrie work
+alwaysApply: true
+---
+
+# Branch naming
+
+## Format
+
+Use:
+
+```text
+<user>/for-<issue-no>-<short-desc>
+```
+
+- **`<user>`** — short branch owner prefix (see [User aliases](#user-aliases)).
+- **`for-<issue-no>`** — Linear issue number only (e.g. `167` → `for-167`), team
+  key **`FOR`** implied.
+- **`<short-desc>`** — kebab-case slug (lowercase, hyphens); keep it short and
+  specific.
+
+Examples: `robin/for-167-onboard-design`, `robin/for-170-token-binding`.
+
+## Issue selection
+
+- One branch maps to **one Linear issue**.
+- When work is part of a **series** with a logical parent, use the **parent**
+  issue number in the branch name; let **`<short-desc>`** disambiguate the slice
+  (e.g. parent `FOR-167`, branches `robin/for-167-request-api` and
+  `robin/for-167-token-binding`).
+- Do not invent issue numbers — resolve or create the issue first (see below).
+
+## Default user prefix
+
+When creating a branch, set **`<user>`** from the GitHub username:
+
+1. Prefer `gh api user --jq .login` (or equivalent) when GitHub CLI is
+   available.
+2. Otherwise use the configured git user email/name only if it clearly maps to
+   a [user alias](#user-aliases) entry.
+3. Map the GitHub username through **User aliases**; if there is no alias, use
+   the GitHub username as-is (lowercase).
+
+## User aliases
+
+Map GitHub usernames to the short **`<user>`** prefix used in branch names.
+Add rows here as people join the project.
+
+| GitHub username | Branch prefix |
+|-----------------|---------------|
+| `robinbryce`    | `robin`       |
+| `robin0f7`      | `robin`       |
+
+## Creating branches
+
+Before `git checkout -b`:
+
+1. **Find the issue** — search Linear (team **`FOR`**) for an existing issue
+   that matches the work. Follow [linear-mcp-forestrie.mdc](./linear-mcp-forestrie.mdc)
+   for MCP identity checks.
+2. **If no suitable issue exists**, create one on team **Forestrie (`FOR`)**:
+   - **Title:** concise summary derived from the original prompt or task.
+   - **Description:** minimal context — problem or change in one short
+     paragraph.
+   - **Acceptance criteria:** bullet list of **testable** outcomes (behaviour,
+     API responses, tests that must pass, observable fixes). Avoid vague
+     goals like "improve quality" without verifiable checks.
+3. **Name the branch** with the resolved issue number and slug, then create it
+   from the intended base branch (usually `main`).
+
+Do not create a branch without a linked **`FOR-*`** issue unless the user
+explicitly asks to skip issue tracking.

--- a/.cursor/rules/solidity-comments.mdc
+++ b/.cursor/rules/solidity-comments.mdc
@@ -1,0 +1,65 @@
+---
+description: Solidity comment policy — NatSpec, signposts, and wrap rules
+globs: **/*.sol
+alwaysApply: false
+---
+
+# Solidity comments
+
+Forestrie is a **highly distributed system**. On-chain verification assumes
+off-chain grant publication, log hierarchy, and signer behaviour documented
+across repositories. Comments must make those obligations reachable without
+duplicating platform docs.
+
+**Line wrapping:** follow **Comment wrapping (Solidity)** in [`.cursorrules`](../.cursorrules)
+(79/100 columns, tag continuation, `forge fmt` last). This rule covers **content**
+and **cross-repo signposts**; `.cursorrules` covers **format**.
+
+## Principles
+
+1. **Signpost, don't silo.** State how the contract or library fits the wider
+   auth and checkpoint flow; name off-chain dependencies and on-chain invariants.
+2. **Brief with a pointer.** One or two sentences plus a doc link is enough
+   unless the interaction is security-critical.
+3. **Explain purpose, not syntax.** NatSpec describes **role**, **invariants**,
+   and **trust assumptions** — not a narration of each opcode.
+4. **Non-obvious details only at line level.** Use `//` for surprising
+   mechanics (gas bounds, calldata layout, MMR edge cases).
+5. **Full coverage of public surfaces.** Every **public** and **external**
+   function, event, error, and exported type needs `@notice`; document
+   `@param` / `@return` when types alone do not convey constraints.
+
+## Cross-repo signposts
+
+Prefer stable **GitHub blob links** in `@dev` or `@notice`:
+
+```solidity
+/// @notice Verifies a checkpoint grant against the owner log's published root.
+/// @dev Off-chain grant shape and inclusion rules:
+/// https://github.com/forestrie/devdocs/blob/main/arc/arc-0019-grant-verification-model.md
+```
+
+| Target | Link form |
+|--------|-----------|
+| Repo-local ARC | `https://github.com/forestrie/univocity/blob/main/docs/arc/…` |
+| Platform ADR/ARC | `https://github.com/forestrie/devdocs/blob/main/arc/…` |
+| SCRAPI / Workers | `https://github.com/forestrie/canopy/blob/main/docs/…` |
+| Go services | `https://github.com/forestrie/arbor/blob/main/services/…` |
+
+Name the **remote component**, **contract** (route, COSE label, storage slot),
+and what this code **assumes** vs **guarantees**.
+
+## What to write at each level
+
+| Level | Comment answers |
+|-------|-----------------|
+| **File / contract** | Role in checkpoint verification; trust boundaries. |
+| **Library** | Crypto or encoding obligation; callers' preconditions. |
+| **Function** | Authorization step performed; revert conditions worth knowing. |
+| **Line** | Non-obvious mechanics only. |
+
+## When editing
+
+- Security-sensitive or cross-repo behaviour → update NatSpec in the same change.
+- Do not copy ARC/ADR prose into source — link and state the local obligation.
+- Run `forge fmt` after comment edits; do not manually re-wrap afterward.

--- a/.cursor/rules/types-single-responsibility.mdc
+++ b/.cursor/rules/types-single-responsibility.mdc
@@ -1,0 +1,34 @@
+---
+description: One Solidity type/library per file; module layout
+alwaysApply: true
+---
+
+# Types and single responsibility (Solidity)
+
+Do **not** use monolithic catch-all files (`Types.sol`, `Helpers.sol`) that mix
+unrelated domains.
+
+## Rule
+
+- **One library per file** under `src/<module>/lib/`.
+- **Interfaces and events** live under `src/<module>/interfaces/` — one primary
+  interface (or tightly coupled interface group) per file.
+- **Shared domain types** for a module live in `src/<module>/<Type>.sol` when
+  not tied to a single library.
+- **Deployable contracts** compose modules under `src/contracts/`; keep each
+  deployable focused — delegate crypto to `lib/`.
+- Include **closely related** constants, errors, or helper types in the same
+  file as the primary type they serve.
+
+## File naming
+
+- Name files after the primary type (`LibCose.sol`, `IUnivocity.sol`).
+- Prefer PascalCase matching the Solidity type name.
+
+## Imports
+
+- Use **explicit named imports** only (see `.cursorrules`).
+- Prefer importing from the concrete module path; avoid barrel files that hide
+  dependencies.
+
+See [docs/agents/solidity.md](../docs/agents/solidity.md) for module layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@
 
 - **`.cursorrules`** — Solidity imports and comment wrapping; see
   [docs/agents/solidity.md](docs/agents/solidity.md) for layout.
+- **`.cursor/rules/`** — [branch-naming](.cursor/rules/branch-naming.mdc),
+  [solidity-comments](.cursor/rules/solidity-comments.mdc) (cross-repo NatSpec;
+  wrapping stays in `.cursorrules`), [types-single-responsibility](.cursor/rules/types-single-responsibility.mdc).
 
 ## Source layout
 


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/branch-naming.mdc` (FOR team / Linear linkage)
- Add language-specific comment and single-responsibility rules
- Update AGENTS.md pointers where applicable

## Linear
FOR-179

## Test plan
- [x] Rules are markdown only; no runtime changes

Made with [Cursor](https://cursor.com)