### PR TITLE
chore(release): pin tools v0.6.0 and README v0.1.4 examples (FOR-156)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       tools_version:
         description: "univocity-tools release tag"
         required: false
-        default: "v0.4.0"
+        default: "v0.6.0"
         type: string
 
 jobs:
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build, archive, and validate
         env:
-          UNIVOCITY_TOOLS_VERSION: ${{ inputs.tools_version || 'v0.4.0' }}
+          UNIVOCITY_TOOLS_VERSION: ${{ inputs.tools_version || 'v0.6.0' }}
         run: task contract-artefacts-release:release
 
       - name: Generate deploy manifest

--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ using the prebuilt [univocity-tools deployer](https://github.com/forestrie/univo
 binary — no `forge`, `cast`, or clone of this repo.
 
 1. Download `deployer-linux-x64` or `deployer-darwin-arm64` (+ `.sha256`) from
-   an [univocity-tools release](https://github.com/forestrie/univocity-tools/releases).
+   the [univocity-tools v0.6.0 release](https://github.com/forestrie/univocity-tools/releases/tag/v0.6.0)
+   (or a newer tag).
 2. One-shot EOA deploy (uses `deploy-manifest-<tag>.json` when present):
 
 ```shell
 ./deployer-darwin-arm64 deploy imutable \
-  --from-release v0.4.0 \
+  --from-release v0.1.4 \
   --bootstrap-alg ks256 \
   --bootstrap-ks256-signer 0xYourSigner \
   --deploy-key "$DEPLOY_KEY" \
@@ -139,14 +140,14 @@ Published **build archives** (see [ADR-0007](docs/adr/adr-0007-contract-release-
 
 Each archive is round-trip validated with `contract-artefacts archive-extract`
 and `archive-validate` before publish. Requires
-[univocity-tools](https://github.com/forestrie/univocity-tools) `v0.4.0+`
+[univocity-tools](https://github.com/forestrie/univocity-tools) `v0.6.0+`
 (`contract-artefacts` binary).
 
 Local dry-run (downloads Linux `contract-artefacts` on CI; on macOS use a local
 Cart build or `workflow_dispatch`):
 
 ```shell
-UNIVOCITY_TOOLS_VERSION=v0.4.0 task contract-artefacts-release:release
+UNIVOCITY_TOOLS_VERSION=v0.6.0 task contract-artefacts-release:release
 ls -la .work/univocity-*.tar.gz .work/create3-factory-*.tar.gz
 ```
 

--- a/taskfiles/contract-artefacts-release.yml
+++ b/taskfiles/contract-artefacts-release.yml
@@ -1,9 +1,9 @@
 # Build archives for contracts release via univocity-tools contract-artefacts.
-# Local: UNIVOCITY_TOOLS_VERSION=v0.4.0 task contract-artefacts-release:release
+# Local: UNIVOCITY_TOOLS_VERSION=v0.6.0 task contract-artefacts-release:release
 version: "3"
 
 vars:
-  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.4.0"}}'
+  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.6.0"}}'
   TOOLS_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-tools"
   CART_BIN: "{{.TOOLS_CACHE_DIR}}/contract-artefacts-linux-x64"
   WORK_DIR: "{{.ROOT_DIR}}/.work"

--- a/taskfiles/imutable-deploy.yml
+++ b/taskfiles/imutable-deploy.yml
@@ -4,8 +4,8 @@
 version: "3"
 
 vars:
-  UNIVOCITY_VERSION: '{{.UNIVOCITY_VERSION | default "v0.4.0"}}'
-  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.4.0"}}'
+  UNIVOCITY_VERSION: '{{.UNIVOCITY_VERSION | default "v0.1.4"}}'
+  UNIVOCITY_TOOLS_VERSION: '{{.UNIVOCITY_TOOLS_VERSION | default "v0.6.0"}}'
   DEPLOYER_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-tools"
   MANIFEST_CACHE_DIR: "{{.ROOT_DIR}}/.cache/univocity-manifest"
   ALG: '{{.ALG | default "es256"}}'


### PR DESCRIPTION
## Summary
- Default `UNIVOCITY_TOOLS_VERSION` to **v0.6.0** in release workflow and taskfiles.
- Update consumer deploy README examples to **v0.1.4** (upcoming tag) and tools **v0.6.0**.

## Test plan
- [ ] CI green on PR
- [ ] After merge: tag `v0.1.4` and verify `deploy-manifest-v0.1.4.json` on release


Made with [Cursor](https://cursor.com)