### PR TITLE
feat(release): emit UUPSUnivocity and ERC1967Proxy in deploy-manifest (FOR-153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ re-initialization.
 ### Consumer deploy (no Foundry required)
 
 Independent operators can deploy **ImutableUnivocity** from a published release
-using the prebuilt [univocity-tools deployer](https://github.com/forestrie/univocity-tools/releases)
-binary — no `forge`, `cast`, or clone of this repo.
+using either:
+
+- **Browser:** [univocity-deploy](https://univocity-deploy.pages.dev) — Privy or
+  injected wallet, verified `deploy-manifest` + sidecar, genesis JSON download.
+- **CLI:** prebuilt [univocity-tools deployer](https://github.com/forestrie/univocity-tools/releases)
+  binary — no `forge`, `cast`, or clone of this repo.
+
+#### CLI one-shot
 
 1. Download `deployer-linux-x64` or `deployer-darwin-arm64` (+ `.sha256`) from
    the [univocity-tools v0.6.0 release](https://github.com/forestrie/univocity-tools/releases/tag/v0.6.0)
@@ -101,6 +107,13 @@ deterministic address using the shared Arachnid CREATE3 factory. Config in
 `deployment.json`. Secrets via **Doppler** (or `.env`): `RPC_URL`, `PRIVATE_KEY`,
 `UPGRADE_ADMIN`, `BOOTSTRAP_ALG`, `BOOTSTRAP_PUB`. Steps are idempotent (no-op
 when factory or proxy already deployed).
+
+**Foundry-free operator path:** use the [univocity-tools deployer](https://github.com/forestrie/univocity-tools)
+binary — `deploy create3 --from-release <tag>` then
+`deploy uups --from-release <tag>` (see
+[ADR-0012 in univocity-tools](https://github.com/forestrie/univocity-tools/blob/main/docs/adr/adr-0012-foundry-free-uups-deploy.md)).
+Requires a release whose deploy-manifest includes `UUPSUnivocity` and
+`ERC1967Proxy` bytecode entries.
 
 ```shell
 task deploy                 # one-shot: factory (if missing), prepare, execute

--- a/scripts/generate_deploy_manifest.py
+++ b/scripts/generate_deploy_manifest.py
@@ -49,10 +49,12 @@ def contract_entry(path: Path) -> dict[str, Any]:
 
     abi = artifact.get("abi")
     constructor_abi: list[Any] = []
+    full_abi: list[Any] = []
     if isinstance(abi, list):
         constructor_abi = [
             item for item in abi if isinstance(item, dict) and item.get("type") == "constructor"
         ]
+        full_abi = [item for item in abi if isinstance(item, dict)]
 
     entry: dict[str, Any] = {
         "contractName": contract_name,
@@ -62,6 +64,8 @@ def contract_entry(path: Path) -> dict[str, Any]:
     }
     if constructor_abi:
         entry["constructorAbi"] = constructor_abi
+    if full_abi:
+        entry["abi"] = full_abi
     return entry
 
 
@@ -97,6 +101,14 @@ def main(argv: list[str] | None = None) -> int:
     factory_path = Path(args.create3_out_dir) / "CREATE3Factory.sol" / "CREATE3Factory.json"
     if factory_path.is_file():
         contracts["CREATE3Factory"] = contract_entry(factory_path)
+
+    uups_path = out_dir / "UUPSUnivocity.sol" / "UUPSUnivocity.json"
+    if uups_path.is_file():
+        contracts["UUPSUnivocity"] = contract_entry(uups_path)
+
+    proxy_path = out_dir / "ERC1967Proxy.sol" / "ERC1967Proxy.json"
+    if proxy_path.is_file():
+        contracts["ERC1967Proxy"] = contract_entry(proxy_path)
 
     manifest = {
         "version": 1,

--- a/scripts/test_generate_deploy_manifest.py
+++ b/scripts/test_generate_deploy_manifest.py
@@ -100,6 +100,57 @@ class GenerateDeployManifestTest(unittest.TestCase):
                 imutable["bytecodeSha256"], golden_imutable["bytecodeSha256"]
             )
 
+    def test_main_includes_uups_entries_when_artifacts_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = Path(tmp) / "out"
+            for name in ("UUPSUnivocity", "ERC1967Proxy"):
+                artifact_dir = out_dir / f"{name}.sol"
+                artifact_dir.mkdir(parents=True)
+                (artifact_dir / f"{name}.json").write_text(
+                    json.dumps(
+                        {
+                            "bytecode": {"object": "0x6003"},
+                            "metadata": json.dumps(
+                                {"compiler": {"version": "0.8.26+commit.abc"}}
+                            ),
+                            "abi": [{"type": "constructor", "inputs": []}],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+            imutable_dir = out_dir / "ImutableUnivocity.sol"
+            imutable_dir.mkdir(parents=True)
+            (imutable_dir / "ImutableUnivocity.json").write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": "0x6001"},
+                        "metadata": json.dumps(
+                            {"compiler": {"version": "0.8.26+commit.abc"}}
+                        ),
+                        "abi": [{"type": "constructor", "inputs": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = Path(tmp) / "deploy-manifest-v0.4.0.json"
+            self.assertEqual(
+                main(
+                    [
+                        "v0.4.0",
+                        "--out-dir",
+                        str(out_dir),
+                        "--output",
+                        str(output),
+                    ]
+                ),
+                0,
+            )
+            generated = json.loads(output.read_text(encoding="utf-8"))
+            contracts = generated["contracts"]
+            self.assertIn("UUPSUnivocity", contracts)
+            self.assertIn("ERC1967Proxy", contracts)
+            self.assertIn("abi", contracts["UUPSUnivocity"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_verify_deploy_manifest_artifact.py
+++ b/scripts/test_verify_deploy_manifest_artifact.py
@@ -86,6 +86,70 @@ class VerifyDeployManifestArtifactTest(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 verify_main([str(manifest_path), str(artifact_path)])
 
+    def test_accepts_uups_univocity_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "out"
+            imutable_dir = out_dir / "ImutableUnivocity.sol"
+            imutable_dir.mkdir(parents=True)
+            (imutable_dir / "ImutableUnivocity.json").write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": "0x6001"},
+                        "metadata": json.dumps(
+                            {"compiler": {"version": "0.8.26+commit.abc"}}
+                        ),
+                        "abi": [{"type": "constructor", "inputs": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            artifact_dir = out_dir / "UUPSUnivocity.sol"
+            artifact_dir.mkdir(parents=True)
+            bytecode = "0x6002"
+            (artifact_dir / "UUPSUnivocity.json").write_text(
+                json.dumps(
+                    {
+                        "bytecode": {"object": bytecode},
+                        "metadata": json.dumps(
+                            {"compiler": {"version": "0.8.26+commit.abc"}}
+                        ),
+                        "abi": [
+                            {
+                                "type": "function",
+                                "name": "initialize",
+                                "inputs": [],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manifest_path = root / "deploy-manifest-v0.4.0.json"
+            self.assertEqual(
+                generate_main(
+                    [
+                        "v0.4.0",
+                        "--out-dir",
+                        str(out_dir),
+                        "--output",
+                        str(manifest_path),
+                    ]
+                ),
+                0,
+            )
+            self.assertEqual(
+                verify_main(
+                    [
+                        str(manifest_path),
+                        str(artifact_dir / "UUPSUnivocity.json"),
+                        "--contract",
+                        "UUPSUnivocity",
+                    ]
+                ),
+                0,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/verify_deploy_manifest_artifact.py
+++ b/scripts/verify_deploy_manifest_artifact.py
@@ -19,12 +19,17 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="ImutableUnivocity forge artifact JSON path",
     )
+    parser.add_argument(
+        "--contract",
+        default="ImutableUnivocity",
+        help="Manifest contracts key to verify (default: ImutableUnivocity)",
+    )
     args = parser.parse_args(argv)
 
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
-    entry = manifest.get("contracts", {}).get("ImutableUnivocity")
+    entry = manifest.get("contracts", {}).get(args.contract)
     if not isinstance(entry, dict):
-        raise SystemExit("manifest missing contracts.ImutableUnivocity")
+        raise SystemExit(f"manifest missing contracts.{args.contract}")
 
     artifact_entry = contract_entry(args.artifact)
     for field in ("creationBytecode", "bytecodeSha256"):


### PR DESCRIPTION
## Summary
- Extend `generate_deploy_manifest.py` to publish `UUPSUnivocity` and `ERC1967Proxy` entries (with initialize ABI).
- Harden `verify_deploy_manifest_artifact.py` with `--contract` and add Python tests.
- Document foundry-free CREATE3 + UUPS operator path in README.

## Test plan
- [x] `scripts/test_generate_deploy_manifest.py`
- [x] `scripts/test_verify_deploy_manifest_artifact.py`
- [ ] CI release workflow on tag after merge

Linear: FOR-153

Made with [Cursor](https://cursor.com)