### PR TITLE
feat(release): contract release channel metadata (FOR-248)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ on:
         required: false
         default: "v0.6.0"
         type: string
+      channel:
+        description: "Contract release channel for catalog metadata"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - stg
+          - prod
 
 jobs:
   ci:
@@ -54,6 +63,22 @@ jobs:
           python3 scripts/generate_deploy_manifest.py "${TAG}" --out-dir out \
             --create3-out-dir script/create3-factory/out \
             --output "deploy-manifest-${TAG}.json"
+
+      - name: Write release channel catalog entry
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_CHANNEL: ${{ inputs.channel || 'dev' }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          mkdir -p release
+          python3 scripts/update_deployment_release_entry.py \
+            --version "${TAG}" \
+            --channel "${RELEASE_CHANNEL}" \
+            --print-only \
+            > "release/contract-releases-${TAG}.json"
+          ( cd release && shasum -a 256 "contract-releases-${TAG}.json" \
+            > "contract-releases-${TAG}.json.sha256" )
 
       - name: Verify deploy manifest matches artifact
         if: startsWith(github.ref, 'refs/tags/')
@@ -107,3 +132,5 @@ jobs:
             release/*.tar.gz.sha256
             release/deploy-manifest-*.json
             release/deploy-manifest-*.json.sha256
+            release/contract-releases-*.json
+            release/contract-releases-*.json.sha256

--- a/deployment.json
+++ b/deployment.json
@@ -30,5 +30,6 @@
         "UUPSUnivocity": "0xFCd2274b7012eb37c1D1886E2f0Bc89a1677e9F9"
       }
     }
-  }
+  },
+  "releases": []
 }

--- a/deployment.schema.json
+++ b/deployment.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/forestrie/univocity/deployment.schema.json",
+  "title": "Univocity deployment configuration",
+  "type": "object",
+  "required": ["schemaVersion", "shared", "environments"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "v1"
+    },
+    "shared": {
+      "type": "object"
+    },
+    "environments": {
+      "type": "object"
+    },
+    "releases": {
+      "type": "array",
+      "description": "Published contract releases with channel metadata for semver resolution.",
+      "items": {
+        "type": "object",
+        "required": ["version", "channel"],
+        "properties": {
+          "version": {
+            "type": "string",
+            "pattern": "^v\\d+\\.\\d+\\.\\d+$"
+          },
+          "channel": {
+            "type": "string",
+            "enum": ["dev", "stg", "prod"]
+          },
+          "es256Address": {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          },
+          "ks256Address": {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/test_update_deployment_release_entry.py
+++ b/scripts/test_update_deployment_release_entry.py
@@ -1,0 +1,60 @@
+"""Tests for update_deployment_release_entry.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "update_deployment_release_entry.py"
+
+
+class UpdateDeploymentReleaseEntryTest(unittest.TestCase):
+    def test_upserts_version_and_channel(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            deployment = Path(tmp) / "deployment.json"
+            deployment.write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": "v1",
+                        "shared": {},
+                        "environments": {},
+                        "releases": [],
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(deployment),
+                    "--version",
+                    "v0.1.4",
+                    "--channel",
+                    "dev",
+                    "--ks256-address",
+                    "0x6055f9615Edc5b4B7d8C87c75E1B5EE45583492C",
+                ],
+                check=True,
+            )
+            data = json.loads(deployment.read_text(encoding="utf-8"))
+            self.assertEqual(
+                data["releases"],
+                [
+                    {
+                        "version": "v0.1.4",
+                        "channel": "dev",
+                        "ks256Address": "0x6055f9615Edc5b4B7d8C87c75E1B5EE45583492C",
+                    }
+                ],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update_deployment_release_entry.py
+++ b/scripts/update_deployment_release_entry.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Upsert a contract release entry in deployment.json (version + channel)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+CHANNELS = frozenset({"dev", "stg", "prod"})
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Upsert a release entry in deployment.json",
+    )
+    parser.add_argument(
+        "deployment",
+        type=Path,
+        nargs="?",
+        help="Path to deployment.json (omit with --print-only)",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Semver release tag (e.g. v0.1.4)",
+    )
+    parser.add_argument(
+        "--channel",
+        required=True,
+        choices=sorted(CHANNELS),
+        help="Release channel (dev, stg, prod)",
+    )
+    parser.add_argument(
+        "--es256-address",
+        default="",
+        help="Optional deployed ES256 ImutableUnivocity address",
+    )
+    parser.add_argument(
+        "--ks256-address",
+        default="",
+        help="Optional deployed KS256 ImutableUnivocity address",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the release entry JSON array to stdout without writing",
+    )
+    return parser.parse_args()
+
+
+def load_deployment(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path}: root must be a JSON object")
+    return data
+
+
+def normalize_entry(args: argparse.Namespace) -> dict[str, str]:
+    version = args.version.strip()
+    if not version.startswith("v"):
+        version = f"v{version}"
+    entry: dict[str, str] = {
+        "version": version,
+        "channel": args.channel,
+    }
+    if args.es256_address.strip():
+        entry["es256Address"] = args.es256_address.strip()
+    if args.ks256_address.strip():
+        entry["ks256Address"] = args.ks256_address.strip()
+    return entry
+
+
+def upsert_release(
+    deployment: dict[str, Any],
+    entry: dict[str, str],
+) -> None:
+    releases = deployment.get("releases")
+    if releases is None:
+        releases = []
+    if not isinstance(releases, list):
+        raise SystemExit("deployment.json releases must be an array")
+
+    key = (entry["version"], entry["channel"])
+    updated: list[dict[str, str]] = []
+    replaced = False
+    for raw in releases:
+        if not isinstance(raw, dict):
+            raise SystemExit("deployment.json release entry must be an object")
+        current_key = (
+            str(raw.get("version", "")).strip(),
+            str(raw.get("channel", "")).strip(),
+        )
+        if current_key == key:
+            updated.append(entry)
+            replaced = True
+        else:
+            updated.append(raw)
+    if not replaced:
+        updated.append(entry)
+    deployment["releases"] = updated
+
+
+def main() -> None:
+    args = parse_args()
+    entry = normalize_entry(args)
+    if args.print_only:
+        print(json.dumps([entry], indent=2))
+        return
+    if args.deployment is None:
+        raise SystemExit("deployment path is required unless --print-only is set")
+    deployment_path = args.deployment
+    deployment = load_deployment(deployment_path)
+    upsert_release(deployment, entry)
+    with deployment_path.open("w", encoding="utf-8") as handle:
+        json.dump(deployment, handle, indent=2)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `releases` array to `deployment.json` with JSON schema (`deployment.schema.json`)
- Add `scripts/update_deployment_release_entry.py` for operator upserts
- Release workflow accepts `channel` input and ships `contract-releases-<tag>.json` assets

## Test plan
- [x] `python3 scripts/test_update_deployment_release_entry.py`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)